### PR TITLE
Configure the Pyodide URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ jupyterlab_classic/labextension
 # playwright
 app/artifacts/videos
 app/test/data
+
+# extras
+# do not include kernels such as Pyodide
+app/kernels

--- a/packages/pyodide-kernel-extension/package.json
+++ b/packages/pyodide-kernel-extension/package.json
@@ -38,6 +38,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
+    "@jupyterlab/coreutils": "^5.0.0",
     "@jupyterlite/kernel": "^0.1.0",
     "@jupyterlite/pyodide-kernel": "^0.1.0",
     "@jupyterlite/server": "^0.1.0"

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+
 import {
   JupyterLiteServer,
   JupyterLiteServerPlugin
@@ -11,6 +13,12 @@ import { IKernel, IKernelSpecs } from '@jupyterlite/kernel';
 import { PyodideKernel } from '@jupyterlite/pyodide-kernel';
 
 /**
+ * The default CDN fallback for Pyodide
+ */
+const PYODIDE_CDN_URL =
+  'https://pyodide-cdn2.iodide.io/v0.17.0a2/full/pyodide.js';
+
+/**
  * A plugin to register the Pyodide kernel.
  */
 const kernel: JupyterLiteServerPlugin<void> = {
@@ -18,6 +26,11 @@ const kernel: JupyterLiteServerPlugin<void> = {
   autoStart: true,
   requires: [IKernelSpecs],
   activate: (app: JupyterLiteServer, kernelspecs: IKernelSpecs) => {
+    const url = PageConfig.getOption('pyodideUrl') ?? PYODIDE_CDN_URL;
+    const pyodideUrl = URLExt.isLocal(url)
+      ? URLExt.join(window.location.origin, url)
+      : url;
+
     kernelspecs.register({
       spec: {
         name: 'python',
@@ -38,7 +51,10 @@ const kernel: JupyterLiteServerPlugin<void> = {
         }
       },
       create: async (options: IKernel.IOptions): Promise<IKernel> => {
-        return new PyodideKernel(options);
+        return new PyodideKernel({
+          ...options,
+          pyodideUrl
+        });
       }
     });
   }

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -26,7 +26,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
   autoStart: true,
   requires: [IKernelSpecs],
   activate: (app: JupyterLiteServer, kernelspecs: IKernelSpecs) => {
-    const url = PageConfig.getOption('pyodideUrl') ?? PYODIDE_CDN_URL;
+    const url = PageConfig.getOption('pyodideUrl') || PYODIDE_CDN_URL;
     const pyodideUrl = URLExt.isLocal(url)
       ? URLExt.join(window.location.origin, url)
       : url;


### PR DESCRIPTION
Fixes #23 

This makes it possible to serve the Pyodide assets from locally (useful when offline).

![image](https://user-images.githubusercontent.com/591645/114264894-e8fb1500-99ed-11eb-9cee-692cc0a0cb95.png)
