### PR TITLE
Remove the IFrame on dispose

### DIFF
--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -19,6 +19,9 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
     // create the main IFrame
     this._iframe = document.createElement('iframe');
     this._iframe.style.visibility = 'hidden';
+    this._iframe.style.position = 'absolute';
+    // position outside of the page
+    this._iframe.style.top = '-100000px';
     document.body.appendChild(this._iframe);
 
     this._initIFrame(this._iframe).then(() => {

--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -69,6 +69,17 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
   }
 
   /**
+   * Dispose the kernel.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._iframe.remove();
+    super.dispose();
+  }
+
+  /**
    * Handle a kernel_info_request message
    */
   async kernelInfoRequest(): Promise<KernelMessage.IInfoReplyMsg['content']> {


### PR DESCRIPTION
So the IFrame element is correctly removed from the page when the kernel is shut down.