### PR TITLE
Provide an alternative plugin to download files

### DIFF
--- a/app/lab/index.js
+++ b/app/lab/index.js
@@ -76,7 +76,8 @@ window.addEventListener('load', async () => {
   const disabled = [
     '@jupyterlab/apputils-extension:themes',
     '@jupyterlab/apputils-extension:workspaces',
-    '@jupyterlab/application-extension:tree-resolver'
+    '@jupyterlab/application-extension:tree-resolver',
+    '@jupyterlab/docmanager-extension:download'
   ];
   const plugins = (await Promise.all(extensions)).map(mod => {
     let data = mod.default;

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -38,7 +38,11 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/translation": "^3.0.5"
+    "@jupyterlab/application": "^3.0.0",
+    "@jupyterlab/apputils": "^3.0.0",
+    "@jupyterlab/docmanager": "^3.0.0",
+    "@jupyterlab/mainmenu": "^3.0.0",
+    "@jupyterlab/translation": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -6,7 +6,81 @@ import {
   JupyterFrontEnd
 } from '@jupyterlab/application';
 
+import { ICommandPalette, Dialog, showDialog } from '@jupyterlab/apputils';
+
+import { IDocumentManager } from '@jupyterlab/docmanager';
+
+import { IMainMenu } from '@jupyterlab/mainmenu';
+
 import { ITranslator, TranslationManager } from '@jupyterlab/translation';
+
+/**
+ * The command IDs used by the application extension.
+ */
+namespace CommandIDs {
+  export const download = 'docmanager:download';
+}
+
+/**
+ * A plugin providing download commands in the file menu and command palette.
+ */
+const downloadPlugin: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlite/application-extension:download',
+  autoStart: true,
+  requires: [ITranslator, IDocumentManager],
+  optional: [ICommandPalette, IMainMenu],
+  activate: (
+    app: JupyterFrontEnd,
+    translator: ITranslator,
+    docManager: IDocumentManager,
+    palette: ICommandPalette | null,
+    mainMenu: IMainMenu | null
+  ) => {
+    const trans = translator.load('jupyterlab');
+    const { commands, shell } = app;
+    const isEnabled = () => {
+      const { currentWidget } = shell;
+      return !!(currentWidget && docManager.contextForWidget(currentWidget));
+    };
+    commands.addCommand(CommandIDs.download, {
+      label: trans.__('Download'),
+      caption: trans.__('Download the file to your computer'),
+      isEnabled,
+      execute: () => {
+        // Checks that shell.currentWidget is valid:
+        const current = shell.currentWidget;
+        if (isEnabled() && current) {
+          const context = docManager.contextForWidget(current);
+          if (!context) {
+            return showDialog({
+              title: trans.__('Cannot Download'),
+              body: trans.__('No context found for current widget!'),
+              buttons: [Dialog.okButton({ label: trans.__('OK') })]
+            });
+          }
+          const element = document.createElement('a');
+          element.href = `data:text/json;charset=utf-8,${encodeURIComponent(
+            context.model.toString()
+          )}`;
+          element.download = context.path;
+          document.body.appendChild(element);
+          element.click();
+          document.body.removeChild(element);
+        }
+      }
+    });
+
+    const category = trans.__('File Operations');
+
+    if (palette) {
+      palette.addItem({ command: CommandIDs.download, category });
+    }
+
+    if (mainMenu) {
+      mainMenu.fileMenu.addGroup([{ command: CommandIDs.download }], 6);
+    }
+  }
+};
 
 /**
  * A simplified Translator
@@ -21,6 +95,6 @@ const translator: JupyterFrontEndPlugin<ITranslator> = {
   provides: ITranslator
 };
 
-const plugins: JupyterFrontEndPlugin<any>[] = [translator];
+const plugins: JupyterFrontEndPlugin<any>[] = [downloadPlugin, translator];
 
 export default plugins;


### PR DESCRIPTION
To be able to download the files, instead of hitting the `/files` server endpoint.

This depends on the upstream 3.1 lab packages (alpha 5 or greater, to be published).