### PR TITLE
Handle extra slash with the classic opener

### DIFF
--- a/packages/classic-application-extension/src/index.ts
+++ b/packages/classic-application-extension/src/index.ts
@@ -28,7 +28,7 @@ const EDITOR_FACTORY = 'Editor';
 /**
  * A regular expression to match path to notebooks and documents
  */
-const TREE_PATTERN = new RegExp('/(notebooks|edit)\\?path=(.*)');
+const TREE_PATTERN = new RegExp('/(notebooks|edit)\\/?\\?path=(.*)');
 
 /**
  * A plugin to open document in a new browser tab.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jtpio/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

So classic is able to open notebooks and files even if there is an extra slash:

![image](https://user-images.githubusercontent.com/591645/115125852-3f0e2080-9fcb-11eb-9082-9cc3d5800807.png)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Regex change.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

none
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
