### PR TITLE
add stopgap http server with mime types from python

### DIFF
--- a/.binder/jupyterlite-proxy.json
+++ b/.binder/jupyterlite-proxy.json
@@ -9,10 +9,13 @@
         }
       },
       "jupyterlite-js": {
-        "command": ["yarn", "serve", "--port", "{port}"],
+        "command": ["yarn", "serve"],
         "launcher_entry": {
           "icon_path": "docs/_static/icon.svg",
           "title": "JupyterLite (js)"
+        },
+        "environment": {
+          "PORT": "{port}"
         }
       }
     }

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 lint-staged.config.js
 .eslintrc.js
+scripts/serve.js
 
 node_modules
 **/build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,11 +67,20 @@ yarn build:prod
 
 #### Serve
 
+> These are **not real server solutions**, but they _will_ serve all of the assets types
+> (including `.wasm`) correctly for JupyterLite under development, testing, and demo
+> purposes.
+
+To serve with `scripts/serve.js`, based on Node.js's
+[`http`](https://nodejs.org/api/http.html) module:
+
 ```
 yarn serve
 ```
 
-To serve with python's built-in http server:
+To serve with Python's built-in
+[`http.server`](https://docs.python.org/3/library/http.server.html) module (requires
+Python 3.7+):
 
 ```
 yarn serve:py

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "watch": "run-p watch:lib watch:app",
     "watch:lib": "lerna exec --stream --scope @jupyterlite/metapackage yarn watch",
     "watch:app": "lerna exec --stream --stream --parallel --scope \"@jupyterlite/app-classic\" --scope \"@jupyterlite/app-lab\" yarn watch",
-    "serve": "cd app && http-server",
-    "serve:py": "cd app && python -m http.server"
+    "serve": "node scripts/serve.js",
+    "serve:py": "cd app && python -m http.server -b 127.0.0.1"
   },
   "husky": {
     "hooks": {
@@ -56,7 +56,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.5",
     "extra-watch-webpack-plugin": "^1.0.3",
-    "http-server": "^0.12.3",
     "husky": "^3",
     "jest": "^26.4.2",
     "jest-junit": "^11.1.0",

--- a/packages/pyolite-kernel/package.json
+++ b/packages/pyolite-kernel/package.json
@@ -29,7 +29,8 @@
     "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
-    "style/index.js"
+    "style/index.js",
+    "py/**/*.whl"
   ],
   "scripts": {
     "build": "yarn run build:lib",

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -163,7 +163,10 @@ const MIME_TYPES = {
 
   // also jupyter stuff
   '.ipynb': 'application/json',
-  '.jupyterlab-workspace': 'application/json'
+  '.jupyterlab-workspace': 'application/json',
+
+  // pyolite
+  '.data': 'application/wasm'
 };
 
 function serve(request, response) {

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -1,0 +1,192 @@
+/**
+ * An HTTP server derived from:
+ *
+ * https://developer.mozilla.org/en-US/docs/Learn/Server-side/Node_server_without_framework
+ */
+
+const DO_NOT_USE_THIS = `
+********************************************************************************
+* JupyterLite Development Server                      DO NOT USE IN PRODUCTION *
+********************************************************************************
+`;
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', 'app');
+const HOST = process.env['HOST'] || '127.0.0.1';
+const PORT = parseInt(process.env['PORT'] || '5000');
+const PREFIX = process.env['PREFIX'] || '/';
+const ERRORS = { ENOENT: 404 };
+
+const MIME_TYPES = {
+  // from https://github.com/python/cpython/blob/3.9/Lib/mimetypes.py
+  '.a': 'application/octet-stream',
+  '.ai': 'application/postscript',
+  '.aif': 'audio/x-aiff',
+  '.aifc': 'audio/x-aiff',
+  '.aiff': 'audio/x-aiff',
+  '.au': 'audio/basic',
+  '.avi': 'video/x-msvideo',
+  '.bat': 'text/plain',
+  '.bcpio': 'application/x-bcpio',
+  '.bin': 'application/octet-stream',
+  '.bmp': 'image/bmp',
+  '.bmp': 'image/x-ms-bmp',
+  '.c': 'text/plain',
+  '.cdf': 'application/x-netcdf',
+  '.cpio': 'application/x-cpio',
+  '.csh': 'application/x-csh',
+  '.css': 'text/css',
+  '.csv': 'text/csv',
+  '.dll': 'application/octet-stream',
+  '.doc': 'application/msword',
+  '.dot': 'application/msword',
+  '.dvi': 'application/x-dvi',
+  '.eml': 'message/rfc822',
+  '.eps': 'application/postscript',
+  '.etx': 'text/x-setext',
+  '.exe': 'application/octet-stream',
+  '.gif': 'image/gif',
+  '.gtar': 'application/x-gtar',
+  '.h': 'text/plain',
+  '.hdf': 'application/x-hdf',
+  '.htm': 'text/html',
+  '.html': 'text/html',
+  '.ico': 'image/vnd.microsoft.icon',
+  '.ief': 'image/ief',
+  '.jpe': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.jpg': 'image/jpg',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.ksh': 'text/plain',
+  '.latex': 'application/x-latex',
+  '.m1v': 'video/mpeg',
+  '.m3u': 'application/vnd.apple.mpegurl',
+  '.m3u8': 'application/vnd.apple.mpegurl',
+  '.man': 'application/x-troff-man',
+  '.me': 'application/x-troff-me',
+  '.mht': 'message/rfc822',
+  '.mhtml': 'message/rfc822',
+  '.mid': 'audio/midi',
+  '.midi': 'audio/midi',
+  '.mif': 'application/x-mif',
+  '.mjs': 'application/javascript',
+  '.mov': 'video/quicktime',
+  '.movie': 'video/x-sgi-movie',
+  '.mp2': 'audio/mpeg',
+  '.mp3': 'audio/mpeg',
+  '.mp4': 'video/mp4',
+  '.mpa': 'video/mpeg',
+  '.mpe': 'video/mpeg',
+  '.mpeg': 'video/mpeg',
+  '.mpg': 'video/mpeg',
+  '.ms': 'application/x-troff-ms',
+  '.nc': 'application/x-netcdf',
+  '.nws': 'message/rfc822',
+  '.o': 'application/octet-stream',
+  '.obj': 'application/octet-stream',
+  '.oda': 'application/oda',
+  '.p12': 'application/x-pkcs12',
+  '.p7c': 'application/pkcs7-mime',
+  '.pbm': 'image/x-portable-bitmap',
+  '.pct': 'image/pict',
+  '.pdf': 'application/pdf',
+  '.pfx': 'application/x-pkcs12',
+  '.pgm': 'image/x-portable-graymap',
+  '.pic': 'image/pict',
+  '.pict': 'image/pict',
+  '.pl': 'text/plain',
+  '.png': 'image/png',
+  '.pnm': 'image/x-portable-anymap',
+  '.pot': 'application/vnd.ms-powerpoint',
+  '.ppa': 'application/vnd.ms-powerpoint',
+  '.ppm': 'image/x-portable-pixmap',
+  '.pps': 'application/vnd.ms-powerpoint',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.ps': 'application/postscript',
+  '.pwz': 'application/vnd.ms-powerpoint',
+  '.py': 'text/x-python',
+  '.pyc': 'application/x-python-code',
+  '.pyo': 'application/x-python-code',
+  '.qt': 'video/quicktime',
+  '.ra': 'audio/x-pn-realaudio',
+  '.ram': 'application/x-pn-realaudio',
+  '.ras': 'image/x-cmu-raster',
+  '.rdf': 'application/xml',
+  '.rgb': 'image/x-rgb',
+  '.roff': 'application/x-troff',
+  '.rtf': 'application/rtf',
+  '.rtx': 'text/richtext',
+  '.sgm': 'text/x-sgml',
+  '.sgml': 'text/x-sgml',
+  '.sh': 'application/x-sh',
+  '.shar': 'application/x-shar',
+  '.snd': 'audio/basic',
+  '.so': 'application/octet-stream',
+  '.src': 'application/x-wais-source',
+  '.sv4cpio': 'application/x-sv4cpio',
+  '.sv4crc': 'application/x-sv4crc',
+  '.svg': 'image/svg+xml',
+  '.swf': 'application/x-shockwave-flash',
+  '.t': 'application/x-troff',
+  '.tar': 'application/x-tar',
+  '.tcl': 'application/x-tcl',
+  '.tex': 'application/x-tex',
+  '.texi': 'application/x-texinfo',
+  '.texinfo': 'application/x-texinfo',
+  '.tif': 'image/tiff',
+  '.tiff': 'image/tiff',
+  '.tr': 'application/x-troff',
+  '.tsv': 'text/tab-separated-values',
+  '.txt': 'text/plain',
+  '.ustar': 'application/x-ustar',
+  '.vcf': 'text/x-vcard',
+  '.wasm': 'application/wasm',
+  '.wav': 'audio/x-wav',
+  '.webm': 'video/webm',
+  '.webmanifest': 'application/manifest+json',
+  '.wiz': 'application/msword',
+  '.wsdl': 'application/xml',
+  '.xbm': 'image/x-xbitmap',
+  '.xlb': 'application/vnd.ms-excel',
+  '.xls': 'application/vnd.ms-excel',
+  '.xml': 'text/xml',
+  '.xpdl': 'application/xml',
+  '.xpm': 'image/x-xpixmap',
+  '.xsl': 'application/xml',
+  '.xul': 'text/xul',
+  '.xwd': 'image/x-xwindowdump',
+  '.zip': 'application/zip',
+
+  // also jupyter stuff
+  '.ipynb': 'application/json',
+  '.jupyterlab-workspace': 'application/json'
+};
+
+function serve(request, response) {
+  let { url, method } = request;
+  url = `${url.slice(PREFIX.length - 1)}`;
+  url = url.endsWith('/') ? `${url}index.html` : url;
+  fs.readFile(path.join(ROOT, url), function(error, content) {
+    const code = error ? ERRORS[error.code] || 500 : 200;
+    console.error(new Date().toISOString(), code, method, url);
+    if (code === 200) {
+      mime = MIME_TYPES[`${path.extname(url)}`] || 'application/octet-stream';
+    } else {
+      content = `<h1>${code}</h1>`;
+      mime = 'text/html';
+    }
+    response.writeHead(code, { 'Content-Type': mime });
+    response.end(content, 'utf-8');
+  });
+}
+
+http.createServer(serve).listen(PORT, HOST, () => {
+  console.warn(DO_NOT_USE_THIS);
+  console.warn(`Serving JupyterLite from: ${ROOT}`);
+  console.warn(`    Serving on host/port: http://${HOST}:${PORT}${PREFIX}\n`);
+  console.warn('Press Ctrl+C to exit');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4516,13 +4516,6 @@ async-mutex@^0.3.1:
   dependencies:
     tslib "^2.1.0"
 
-async@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
-  dependencies:
-    lodash "^4.17.14"
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -4672,11 +4665,6 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
-
-basic-auth@^1.0.3:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-1.1.0.tgz#45221ee429f7ee1e5035be3f51533f1cdfd29884"
-  integrity sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -5196,11 +5184,6 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-colors@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -5422,11 +5405,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-corser@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
-  integrity sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=
-
 cosmiconfig@^5.1.0, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -5610,7 +5588,7 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.1.1:
+debug@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -5908,16 +5886,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
-
-ecstatic@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-3.3.2.tgz#6d1dd49814d00594682c652adb66076a69d46c48"
-  integrity sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==
-  dependencies:
-    he "^1.1.1"
-    mime "^1.6.0"
-    minimist "^1.1.0"
-    url-join "^2.0.5"
 
 electron-to-chromium@^1.3.649:
   version "1.3.711"
@@ -6242,11 +6210,6 @@ eventemitter3@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
-
-eventemitter3@^4.0.0:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
-  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
 events@^3.2.0:
   version "3.3.0"
@@ -6615,11 +6578,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-follow-redirects@^1.0.0:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
-  integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -7120,7 +7078,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-he@1.2.x, he@^1.1.1:
+he@1.2.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -7200,31 +7158,6 @@ http-proxy-agent@^2.1.0:
   dependencies:
     agent-base "4"
     debug "3.1.0"
-
-http-proxy@^1.18.0:
-  version "1.18.1"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
-  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
-  dependencies:
-    eventemitter3 "^4.0.0"
-    follow-redirects "^1.0.0"
-    requires-port "^1.0.0"
-
-http-server@^0.12.3:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/http-server/-/http-server-0.12.3.tgz#ba0471d0ecc425886616cb35c4faf279140a0d37"
-  integrity sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==
-  dependencies:
-    basic-auth "^1.0.3"
-    colors "^1.4.0"
-    corser "^2.0.1"
-    ecstatic "^3.3.2"
-    http-proxy "^1.18.0"
-    minimist "^1.2.5"
-    opener "^1.5.1"
-    portfinder "^1.0.25"
-    secure-compare "3.0.1"
-    union "~0.5.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -8718,7 +8651,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.x, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9001,11 +8934,6 @@ mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19:
   dependencies:
     mime-db "1.47.0"
 
-mime@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
-  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-
 mime@^2.3.1, mime@^2.4.6:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
@@ -9074,7 +9002,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.0:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -9166,7 +9094,7 @@ mkdirp@*, mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.5:
+mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -9647,7 +9575,7 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
-opener@^1.5.1, opener@^1.5.2:
+opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
@@ -10082,15 +10010,6 @@ popper.js@^1.14.4, popper.js@^1.16.1:
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
-portfinder@^1.0.25:
-  version "1.0.28"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
-  integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
-  dependencies:
-    async "^2.6.2"
-    debug "^3.1.1"
-    mkdirp "^0.5.5"
-
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -10342,7 +10261,7 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@^6.4.0, qs@^6.9.4:
+qs@^6.9.4:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
@@ -11080,11 +10999,6 @@ schema-utils@^3.0.0:
     "@types/json-schema" "^7.0.6"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
-
-secure-compare@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
-  integrity sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=
 
 semver-compare@^1.0.0:
   version "1.0.0"
@@ -12255,13 +12169,6 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
-union@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/union/-/union-0.5.0.tgz#b2c11be84f60538537b846edb9ba266ba0090075"
-  integrity sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==
-  dependencies:
-    qs "^6.4.0"
-
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -12332,11 +12239,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-url-join@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
-  integrity sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=
 
 url-loader@~4.1.0, url-loader@~4.1.1:
   version "4.1.1"


### PR DESCRIPTION
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bollwyvl/jupyterlite/pyolite-serve-js-wasm?urlpath=lab)

## References

- fixes #59

## Code changes

- drops `http.server`
- add `scripts/serve.js`
  - not in-tree, because we can't ship this trash
  - mostly derived from, and may need better attribution to:
    - [MDN](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Node_server_without_framework)
    - [cpython](https://github.com/python/cpython/blob/3.9/Lib/mimetypes.py)

## User-facing changes

- n/a

## Backwards-incompatible changes

- uses env vars instead of parsing argv :shrug:
- sets them both to bind to `127.0.0.1` because it's _literally_ the least we can do
