### PR TITLE
Add TypeScript API documentation with typedoc

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -10,6 +10,8 @@ dependencies:
   - jupyterlab >=3,<4
   - jupyterlab-classic
   - git
+  # extra docs tools
+  - sphinx-autobuild
 
   ### DOCS ENV ###
   # runtimes
@@ -24,5 +26,6 @@ dependencies:
   # docs
   - myst-nb
   - pydata-sphinx-theme
+  - pytest-check-links
   - sphinx
   ### DOCS ENV ###

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
-      - name: Setup pip (dependencies)
+      - name: Setup pip (dependecies)
         run: |
           pip install -r requirements-docs.txt
       - name: Install
@@ -78,11 +78,10 @@ jobs:
           doit check
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: jupyterlite dist ${{ github.run_number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
           doit check
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     needs: [build]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,12 @@ jobs:
         with:
           path: ~/.cache/pip
           key: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Setup pip (dependecies)
         run: |
-          pip install -r requirements.txt
+          pip install -r requirements-docs.txt
       - name: Install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: |
@@ -70,6 +70,12 @@ jobs:
       - name: Test
         run: |
           doit test
+      - name: Docs
+        run: |
+          doit docs
+      - name: Check Built Artifacts
+        run: |
+          doit check
 
   deploy:
     needs: [build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: '*'
 
 env:
-  CACHE_EPOCH: 0
+  CACHE_EPOCH: 1
 
 jobs:
   build:
@@ -39,6 +39,9 @@ jobs:
             ${{ env.CACHE_EPOCH }}-yarn-packages-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-yarn-packages-
+      - name: Setup pip (pip)
+        run: |
+          pip install -U pip setuptools wheel
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
@@ -46,9 +49,8 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
-      - name: Setup
+      - name: Setup pip (dependecies)
         run: |
-          pip install -U pip setuptools
           pip install -r requirements.txt
       - name: Install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -73,8 +75,6 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: jupyterlite dist ${{ github.run_number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,8 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: jupyterlite dist ${{ github.run_number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
           doit test
 
   deploy:
+    if: secrets.VERCEL_TOKEN == ''
     needs: [build]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
           doit test
 
   deploy:
+    if: ${{ secrets.VERCEL_TOKEN != '' }}
     needs: [build]
     runs-on: ubuntu-latest
     steps:
@@ -94,7 +95,6 @@ jobs:
         env:
           REF: ${{ github.ref }}
       - uses: amondnet/vercel-action@v20
-        if: secrets.VERCEL_TOKEN != ''
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,6 @@ jobs:
           doit test
 
   deploy:
-    if: secrets.VERCEL_TOKEN == ''
     needs: [build]
     runs-on: ubuntu-latest
     steps:
@@ -95,6 +94,7 @@ jobs:
         env:
           REF: ${{ github.ref }}
       - uses: amondnet/vercel-action@v20
+        if: secrets.VERCEL_TOKEN != ''
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,6 @@ jobs:
           doit test
 
   deploy:
-    if: ${{ secrets.VERCEL_TOKEN != '' }}
     needs: [build]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
-      - name: Setup pip (dependecies)
+      - name: Setup pip (dependencies)
         run: |
           pip install -r requirements-docs.txt
       - name: Install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,10 +78,11 @@ jobs:
           doit check
 
   deploy:
-    if: github.ref == 'refs/heads/main'
     needs: [build]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: jupyterlite dist ${{ github.run_number }}

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ app/kernels
 *.log
 
 .doit*
+
+# generated
+docs/api/ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@
 build
 docs/_build
 node_modules
+docs/api/ts
+.pytest_cache

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,5 @@
+# API
+
+```{toctree}
+ts/index.md
+```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,7 @@
 # API
 
 ```{toctree}
+:caption: TypeScript API
+:maxdepth: 2
 ts/index.md
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,8 @@ extensions = [
 ]
 
 autosectionlabel_prefix_document = True
+myst_heading_anchors = 3
+suppress_warnings = ["autosectionlabel.*"]
 
 # files
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,4 +71,4 @@ html_context = {
 if os.environ.get("READTHEDOCS"):
     import subprocess
 
-    subprocess.check_call(["doit", "build"], cwd=str(ROOT))
+    subprocess.check_call(["doit", "build", "typedoc:mystify"], cwd=str(ROOT))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,4 +71,4 @@ html_context = {
 if os.environ.get("READTHEDOCS"):
     import subprocess
 
-    subprocess.check_call(["doit", "build", "typedoc:mystify"], cwd=str(ROOT))
+    subprocess.check_call(["doit", "build", "docs:typedoc:mystify"], cwd=str(ROOT))

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,5 +19,6 @@ dependencies:
   # docs
   - myst-nb
   - pydata-sphinx-theme
+  - pytest-check-links
   - sphinx
   ### DOCS ENV ###

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@
 :maxdepth: 1
 
 kernels/index
+api/index
 contributing
 changelog
 ```

--- a/dodo.py
+++ b/dodo.py
@@ -200,13 +200,14 @@ def task_watch():
         file_dep=[B.YARN_INTEGRITY],
         actions=[U.do("yarn", "watch")],
     )
-    yield dict(
-        name="docs",
-        doc="watch .md sources and rebuild the documentation",
-        uptodate=[lambda: False],
-        file_dep=[*P.DOCS_MD, *P.DOCS_PY, B.APP_PACK],
-        actions=[U.do("sphinx-autobuild", P.DOCS, B.DOCS)],
-    )
+    if shutil.which("sphinx-autobuild"):
+        yield dict(
+            name="docs",
+            doc="watch .md sources and rebuild the documentation",
+            uptodate=[lambda: False],
+            file_dep=[*P.DOCS_MD, *P.DOCS_PY, B.APP_PACK],
+            actions=[U.do("sphinx-autobuild", P.DOCS, B.DOCS)],
+        )
 
 
 def task_test():

--- a/dodo.py
+++ b/dodo.py
@@ -24,6 +24,9 @@ def task_setup():
     args = ["yarn", "--prefer-offline", "--ignore-optional"]
 
     if C.CI:
+        # .yarn-integrity will only exist on a full cache hit vs yarn.lock, saves 1min+
+        if B.YARN_INTEGRITY.exists():
+            return
         args += ["--frozen-lockfile"]
 
     yield dict(

--- a/dodo.py
+++ b/dodo.py
@@ -338,7 +338,14 @@ class U:
     @staticmethod
     def do(*args, cwd=P.ROOT, **kwargs):
         """wrap a CmdAction for consistency"""
-        return doit.tools.CmdAction(list(args), shell=False, cwd=str(Path(cwd)))
+        cmd = args[0]
+        cmd = Path(
+            shutil.which(cmd)
+            or shutil.which(f"{cmd}.exe")
+            or shutil.which(f"{cmd}.cmd")
+            or shutil.which(f"{cmd}.bat")
+        ).resolve()
+        return doit.tools.CmdAction([cmd, *args[1:]], shell=False, cwd=str(Path(cwd)))
 
     @staticmethod
     def ok(ok, **task):

--- a/dodo.py
+++ b/dodo.py
@@ -46,6 +46,8 @@ def task_setup():
 
 def task_lint():
     """format and ensure style of code, docs, etc."""
+    if C.RTD:
+        return
 
     yield U.ok(
         B.OK_PRETTIER,
@@ -226,6 +228,7 @@ class C:
     APPS = ["classic", "lab"]
     ENC = dict(encoding="utf-8")
     CI = bool(json.loads(os.environ.get("CI", "0")))
+    RTD = bool(json.loads(os.environ.get("READTHEDOCS", "0")))
     DOCS_ENV_MARKER = "### DOCS ENV ###"
     NO_TYPEDOC = ["_metapackage"]
 

--- a/dodo.py
+++ b/dodo.py
@@ -228,7 +228,7 @@ class C:
     APPS = ["classic", "lab"]
     ENC = dict(encoding="utf-8")
     CI = bool(json.loads(os.environ.get("CI", "0")))
-    RTD = bool(json.loads(os.environ.get("READTHEDOCS", "0")))
+    RTD = bool(json.loads(os.environ.get("READTHEDOCS", "False").lower()))
     DOCS_ENV_MARKER = "### DOCS ENV ###"
     NO_TYPEDOC = ["_metapackage"]
 

--- a/dodo.py
+++ b/dodo.py
@@ -1,8 +1,11 @@
 import json
 import os
+import re
+import shutil
 from pathlib import Path
 
 import doit
+from collections import defaultdict
 
 
 def task_env():
@@ -53,7 +56,7 @@ def task_lint():
         B.OK_ESLINT,
         name="eslint",
         doc="format and verify .ts, .js files with eslint",
-        file_dep=[B.OK_PRETTIER],
+        file_dep=[B.OK_PRETTIER, *L.ALL_ESLINT],
         actions=[U.do("yarn", "eslint:check" if C.CI else "eslint")],
     )
 
@@ -71,7 +74,12 @@ def task_build():
     yield dict(
         name="js:lib",
         doc="build .ts files into .js files",
-        file_dep=[*L.ALL_TS, P.ROOT_PACKAGE_JSON, *P.PACKAGE_JSONS, B.YARN_INTEGRITY],
+        file_dep=[
+            *L.ALL_ESLINT,
+            P.ROOT_PACKAGE_JSON,
+            *P.PACKAGE_JSONS,
+            B.YARN_INTEGRITY,
+        ],
         actions=[
             U.do("yarn", "build:lib"),
         ],
@@ -131,11 +139,46 @@ def task_build():
 def task_docs():
     """build documentation"""
     yield dict(
+        name="typedoc:ensure",
+        file_dep=[*P.PACKAGE_JSONS],
+        actions=[U.typedoc_conf],
+        targets=[P.TYPEDOC_JSON, P.TSCONFIG_TYPEDOC],
+    )
+    yield dict(
+        name="typedoc:build",
+        doc="build the TS API documentation with typedoc",
+        file_dep=[B.META_BUILDINFO, *P.TYPEDOC_CONF],
+        actions=[U.do("yarn", "docs")],
+        targets=[B.DOCS_RAW_TYPEDOC_README],
+    )
+
+    yield dict(
+        name="typedoc:mystify",
+        doc="transform raw typedoc into myst markdown",
+        file_dep=[B.DOCS_RAW_TYPEDOC_README],
+        targets=[B.DOCS_TS_MYST_INDEX, *B.DOCS_TS_MODULES],
+        actions=[U.mystify, U.do("yarn", "prettier")],
+    )
+
+    yield dict(
         name="sphinx",
         doc="build the documentation site with sphinx",
-        file_dep=[*P.DOCS_MD, *P.DOCS_PY, B.APP_PACK],
+        file_dep=[B.DOCS_TS_MYST_INDEX, *P.DOCS_MD, *P.DOCS_PY, B.APP_PACK],
         actions=[U.do("sphinx-build", "-b", "html", P.DOCS, B.DOCS)],
         targets=[B.DOCS_BUILDINFO],
+    )
+
+
+@doit.create_after("docs")
+def task_check():
+    """perform checks of built artifacts"""
+    yield dict(
+        name="docs:links",
+        doc="check for broken (internal) links",
+        file_dep=[*B.DOCS.rglob("*.html")],
+        actions=[
+            U.do("pytest-check-links", B.DOCS, "--check-links-ignore", "^https?://")
+        ],
     )
 
 
@@ -174,13 +217,14 @@ class C:
     ENC = dict(encoding="utf-8")
     CI = bool(json.loads(os.environ.get("CI", "0")))
     DOCS_ENV_MARKER = "### DOCS ENV ###"
+    NO_TYPEDOC = ["_metapackage"]
 
 
 class P:
     DODO = Path(__file__)
     ROOT = DODO.parent
     PACKAGES = ROOT / "packages"
-    PACKAGE_JSONS = [*PACKAGES.glob("*/package.json")]
+    PACKAGE_JSONS = sorted(PACKAGES.glob("*/package.json"))
     ROOT_PACKAGE_JSON = ROOT / "package.json"
     YARN_LOCK = ROOT / "yarn.lock"
 
@@ -190,7 +234,7 @@ class P:
     APP = ROOT / "app"
     APP_PACKAGE_JSON = APP / "package.json"
     WEBPACK_CONFIG = APP / "webpack.config.js"
-    APP_JSONS = [*APP.glob("*/package.json")]
+    APP_JSONS = sorted(APP.glob("*/package.json"))
     APP_NPM_IGNORE = APP / ".npmignore"
 
     # docs
@@ -198,9 +242,15 @@ class P:
     CONTRIBUTING = ROOT / "CONTRIBUTING.md"
     CHANGELOG = ROOT / "CHANGELOG.md"
     DOCS = ROOT / "docs"
+    TSCONFIG_TYPEDOC = ROOT / "tsconfig.typedoc.json"
+    TYPEDOC_JSON = ROOT / "typedoc.json"
+    TYPEDOC_CONF = [TSCONFIG_TYPEDOC, TYPEDOC_JSON]
+    DOCS_SRC_MD = sorted(
+        [p for p in DOCS.rglob("*.md") if "docs/api" not in str(p.as_posix())]
+    )
     DOCS_ENV = DOCS / "environment.yml"
-    DOCS_PY = [*DOCS.rglob("*.py")]
-    DOCS_MD = [*DOCS.rglob("*.md"), README, CONTRIBUTING, CHANGELOG]
+    DOCS_PY = sorted([*DOCS.rglob("*.py")])
+    DOCS_MD = sorted([*DOCS_SRC_MD, README, CONTRIBUTING, CHANGELOG])
 
     # demo
     BINDER = ROOT / ".binder"
@@ -227,11 +277,16 @@ P.PYOLITE_PACKAGES = [
 
 class L:
     # linting
-    ALL_TS = [*P.PACKAGES.rglob("*/src/**/*.js"), *P.PACKAGES.rglob("*/src/**/*.ts")]
-    ALL_JSON = [*P.PACKAGE_JSONS, *P.APP_JSONS, P.ROOT_PACKAGE_JSON, *ALL_TS]
+    ALL_ESLINT = [
+        *P.PACKAGES.rglob("*/src/**/*.js"),
+        *P.PACKAGES.rglob("*/src/**/*.ts"),
+    ]
+    ALL_JSON = set(
+        [*P.PACKAGE_JSONS, *P.APP_JSONS, P.ROOT_PACKAGE_JSON, *P.ROOT.glob("*.json")]
+    )
     ALL_MD = [*P.CI.rglob("*.md"), *P.DOCS_MD]
     ALL_YAML = [*P.ROOT.glob("*.yml"), *P.BINDER.glob("*.yml"), *P.CI.rglob("*.yml")]
-    ALL_PRETTIER = [*ALL_JSON, *ALL_MD, *ALL_YAML]
+    ALL_PRETTIER = [*ALL_JSON, *ALL_MD, *ALL_YAML, *ALL_ESLINT]
     ALL_BLACK = [
         *P.DOCS_PY,
         P.DODO,
@@ -250,8 +305,18 @@ class B:
     DIST = P.ROOT / "dist"
     APP_PACK = DIST / f"""jupyterlite-app-{D.APP["version"]}.tgz"""
     DOCS = P.DOCS / "_build"
-    DOCS_HTML = DOCS / "html"
-    DOCS_BUILDINFO = DOCS_HTML / ".buildinfo"
+    DOCS_BUILDINFO = DOCS / ".buildinfo"
+
+    # typedoc
+    DOCS_RAW_TYPEDOC = BUILD / "typedoc"
+    DOCS_RAW_TYPEDOC_README = DOCS_RAW_TYPEDOC / "README.md"
+    DOCS_TS = P.DOCS / "api/ts"
+    DOCS_TS_MYST_INDEX = DOCS_TS / "index.md"
+    DOCS_TS_MODULES = [
+        P.ROOT / "docs/api/ts" / f"{p.parent.name}.md"
+        for p in P.PACKAGE_JSONS
+        if p.parent.name not in C.NO_TYPEDOC
+    ]
 
     OK = BUILD / "ok"
     OK_PRETTIER = OK / "prettier"
@@ -283,6 +348,98 @@ class U:
         to_chunks = to_env.read_text(**C.ENC).split(marker)
         to_env.write_text(
             "".join([to_chunks[0], marker, from_chunks[1], marker, to_chunks[2]]),
+            **C.ENC,
+        )
+
+    @staticmethod
+    def typedoc_conf():
+        typedoc = json.loads(P.TYPEDOC_JSON.read_text(**C.ENC))
+        typedoc["entryPoints"] = [
+            str((p.parent / "src/index.ts").relative_to(P.ROOT).as_posix())
+            for p in P.PACKAGE_JSONS
+            if p.parent.name not in C.NO_TYPEDOC
+        ]
+        P.TYPEDOC_JSON.write_text(
+            json.dumps(typedoc, indent=2, sort_keys=True), **C.ENC
+        )
+
+        tsconfig = json.loads(P.TSCONFIG_TYPEDOC.read_text(**C.ENC))
+        tsconfig["references"] = [
+            {"path": f"./packages/{p.parent.name}"}
+            for p in P.PACKAGE_JSONS
+            if p.parent.name not in C.NO_TYPEDOC
+        ]
+
+        P.TSCONFIG_TYPEDOC.write_text(
+            json.dumps(tsconfig, indent=2, sort_keys=True), **C.ENC
+        )
+
+    @staticmethod
+    def mystify():
+        """unwrap monorepo docs into per-module docs"""
+        mods = defaultdict(lambda: defaultdict(list))
+        if B.DOCS_TS.exists():
+            shutil.rmtree(B.DOCS_TS)
+
+        def mod_md_name(mod):
+            return mod.replace("@jupyterlite/", "") + ".md"
+
+        for doc in sorted(B.DOCS_RAW_TYPEDOC.rglob("*.md")):
+            if doc.parent == B.DOCS_RAW_TYPEDOC:
+                continue
+            if doc.name == "README.md":
+                continue
+            doc_text = doc.read_text(**C.ENC)
+            doc_lines = doc_text.splitlines()
+            mod_chunks = doc_lines[0].split(" / ")
+            src = mod_chunks[1]
+            if src.startswith("["):
+                src = re.findall(r"\[(.*)/src\]", src)[0]
+            else:
+                src = src.replace("/src", "")
+            pkg = f"""@jupyterlite/{src.replace("/src", "")}"""
+            mods[pkg][doc.parent.name] += [
+                str(doc.relative_to(B.DOCS_RAW_TYPEDOC).as_posix())[:-3]
+            ]
+
+            # rewrite doc and write back out
+            out_doc = B.DOCS_TS / doc.relative_to(B.DOCS_RAW_TYPEDOC)
+            if not out_doc.parent.exists():
+                out_doc.parent.mkdir(parents=True)
+
+            out_text = doc_text.replace("README.md", "index.md")
+            out_text = re.sub(
+                r"## Table of contents(.*?)\n## ",
+                "\n## ",
+                out_text,
+                flags=re.M | re.S,
+            )
+
+            out_doc.write_text(out_text, **C.ENC)
+
+        for mod, sections in mods.items():
+            out_doc = B.DOCS_TS / mod_md_name(mod)
+            mod_lines = [f"# `{mod}`\n"]
+            for label, contents in sections.items():
+                mod_lines += [
+                    f"## {label.title()}\n",
+                    "```{toctree}",
+                    ":maxdepth: 1",
+                    *contents,
+                    "```\n",
+                ]
+            out_doc.write_text("\n".join(mod_lines))
+
+        B.DOCS_TS_MYST_INDEX.write_text(
+            "\n".join(
+                [
+                    "# TypeScript API\n",
+                    "```{toctree}",
+                    ":maxdepth: 1",
+                    *[mod_md_name(mod) for mod in sorted(mods)],
+                    "```",
+                ]
+            ),
             **C.ENC,
         )
 

--- a/dodo.py
+++ b/dodo.py
@@ -354,25 +354,34 @@ class U:
     @staticmethod
     def typedoc_conf():
         typedoc = json.loads(P.TYPEDOC_JSON.read_text(**C.ENC))
-        typedoc["entryPoints"] = [
-            str((p.parent / "src/index.ts").relative_to(P.ROOT).as_posix())
-            for p in P.PACKAGE_JSONS
-            if p.parent.name not in C.NO_TYPEDOC
-        ]
-        P.TYPEDOC_JSON.write_text(
-            json.dumps(typedoc, indent=2, sort_keys=True), **C.ENC
+        original_entry_points = sorted(typedoc["entryPoints"])
+        new_entry_points = sorted(
+            [
+                str((p.parent / "src/index.ts").relative_to(P.ROOT).as_posix())
+                for p in P.PACKAGE_JSONS
+                if p.parent.name not in C.NO_TYPEDOC
+            ]
         )
 
+        if json.dumps(original_entry_points) != json.dumps(new_entry_points):
+            typedoc["entryPoints"] = new_entry_points
+            P.TYPEDOC_JSON.write_text(
+                json.dumps(typedoc, indent=2, sort_keys=True), **C.ENC
+            )
+
         tsconfig = json.loads(P.TSCONFIG_TYPEDOC.read_text(**C.ENC))
-        tsconfig["references"] = [
+        original_references = tsconfig["references"]
+        new_references = [
             {"path": f"./packages/{p.parent.name}"}
             for p in P.PACKAGE_JSONS
             if p.parent.name not in C.NO_TYPEDOC
         ]
 
-        P.TSCONFIG_TYPEDOC.write_text(
-            json.dumps(tsconfig, indent=2, sort_keys=True), **C.ENC
-        )
+        if json.dumps(original_references) != json.dumps(new_references):
+            tsconfig["references"] = new_references
+            P.TSCONFIG_TYPEDOC.write_text(
+                json.dumps(tsconfig, indent=2, sort_keys=True), **C.ENC
+            )
 
     @staticmethod
     def mystify():

--- a/dodo.py
+++ b/dodo.py
@@ -28,7 +28,13 @@ def task_setup():
     yield dict(
         name="js",
         doc="install node packages",
-        file_dep=[P.YARN_LOCK, *P.PACKAGE_JSONS, P.ROOT_PACKAGE_JSON],
+        file_dep=[
+            P.YARN_LOCK,
+            *P.PACKAGE_JSONS,
+            P.ROOT_PACKAGE_JSON,
+            P.APP_PACKAGE_JSON,
+            *P.APP_JSONS,
+        ],
         actions=[U.do(*args)],
         targets=[B.YARN_INTEGRITY],
     )

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "watch:lib": "lerna exec --stream --scope @jupyterlite/metapackage yarn watch",
     "watch:app": "lerna exec --stream --stream --parallel --scope \"@jupyterlite/app-classic\" --scope \"@jupyterlite/app-lab\" yarn watch",
     "serve": "node scripts/serve.js",
-    "serve:py": "cd app && python -m http.server -b 127.0.0.1"
+    "serve:py": "cd app && python -m http.server -b 127.0.0.1",
+    "docs": "typedoc"
   },
   "husky": {
     "hooks": {
@@ -68,6 +69,8 @@
     "prettier": "^1.19.0",
     "rimraf": "^3.0.2",
     "shell-quote": "^1.7.2",
+    "typedoc": "^0.20.36",
+    "typedoc-plugin-markdown": "^3.7.2",
     "typescript": "~4.2.3"
   }
 }

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -1,7 +1,11 @@
 /**
  * Store the kernel and interpreter instances.
  */
+// eslint-disable-next-line
+// @ts-ignore: breaks typedoc
 let kernel: any;
+// eslint-disable-next-line
+// @ts-ignore: breaks typedoc
 let interpreter: any;
 
 /**
@@ -50,6 +54,8 @@ function formatResult(res: any): any {
   return results;
 }
 
+// eslint-disable-next-line
+// @ts-ignore: breaks typedoc
 const pyodideReadyPromise = loadPyodideAndPackages();
 
 self.onmessage = async (event: MessageEvent): Promise<void> => {

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,7 @@
+# minimum needed to build jupyterlite docs... in addition to nodejs and yarn
+# see .binder/ and docs/ for full development/docs environments
+-r requirements.txt
+myst-nb
+pydata-sphinx-theme
+pytest-check-links
+sphinx

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "lib": ["ES2019", "WebWorker", "ScriptHost", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@jupyterlite/*": ["./packages/*/src"]
+    }
+  },
+  "exclude": ["**/test/**"],
+  "extends": "./tsconfigbase",
+  "references": [
+    {
+      "path": "./packages/application"
+    },
+    {
+      "path": "./packages/application-extension"
+    },
+    {
+      "path": "./packages/classic-application-extension"
+    },
+    {
+      "path": "./packages/contents"
+    },
+    {
+      "path": "./packages/iframe-extension"
+    },
+    {
+      "path": "./packages/javascript-kernel"
+    },
+    {
+      "path": "./packages/javascript-kernel-extension"
+    },
+    {
+      "path": "./packages/kernel"
+    },
+    {
+      "path": "./packages/p5-kernel"
+    },
+    {
+      "path": "./packages/p5-kernel-extension"
+    },
+    {
+      "path": "./packages/pyolite-kernel"
+    },
+    {
+      "path": "./packages/pyolite-kernel-extension"
+    },
+    {
+      "path": "./packages/server"
+    },
+    {
+      "path": "./packages/server-extension"
+    },
+    {
+      "path": "./packages/session"
+    },
+    {
+      "path": "./packages/settings"
+    },
+    {
+      "path": "./packages/theme"
+    },
+    {
+      "path": "./packages/theme-extension"
+    }
+  ]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,27 @@
+{
+  "entryPoints": [
+    "packages/application/src/index.ts",
+    "packages/application-extension/src/index.ts",
+    "packages/classic-application-extension/src/index.ts",
+    "packages/contents/src/index.ts",
+    "packages/iframe-extension/src/index.ts",
+    "packages/javascript-kernel/src/index.ts",
+    "packages/javascript-kernel-extension/src/index.ts",
+    "packages/kernel/src/index.ts",
+    "packages/p5-kernel/src/index.ts",
+    "packages/p5-kernel-extension/src/index.ts",
+    "packages/pyolite-kernel/src/index.ts",
+    "packages/pyolite-kernel-extension/src/index.ts",
+    "packages/server/src/index.ts",
+    "packages/server-extension/src/index.ts",
+    "packages/session/src/index.ts",
+    "packages/settings/src/index.ts",
+    "packages/theme/src/index.ts",
+    "packages/theme-extension/src/index.ts"
+  ],
+  "exclude": ["*.spec.ts", "**/node_modules/**", "**/test/**", "**/lib/**"],
+  "name": "@jupyterlite",
+  "out": "build/typedoc",
+  "readme": "none",
+  "tsconfig": "tsconfig.typedoc.json"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5184,6 +5184,11 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
+colors@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -6627,7 +6632,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.1:
+fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -6870,7 +6875,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.6:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -6980,7 +6985,7 @@ gzip-size@^6.0.0:
   dependencies:
     duplexer "^0.1.2"
 
-handlebars@^4.7.6:
+handlebars@^4.7.6, handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -7418,6 +7423,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 interpret@^2.2.0:
   version "2.2.0"
@@ -8718,6 +8728,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 macos-release@^2.2.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.4.1.tgz#64033d0ec6a5e6375155a74b1a1eba8e509820ac"
@@ -8826,6 +8841,11 @@ marked@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.1.tgz#5e7ed7009bfa5c95182e4eb696f85e948cefcee3"
   integrity sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==
+
+marked@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.3.tgz#3551c4958c4da36897bda2a16812ef1399c8d6b0"
+  integrity sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -8978,7 +8998,7 @@ mini-css-extract-plugin@~1.3.2:
     schema-utils "^3.0.0"
     webpack-sources "^1.1.0"
 
-minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -9569,6 +9589,13 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+onigasm@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.5.tgz#cc4d2a79a0fa0b64caec1f4c7ea367585a676892"
+  integrity sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
+  dependencies:
+    lru-cache "^5.1.1"
 
 opencollective-postinstall@^2.0.2:
   version "2.0.3"
@@ -10552,6 +10579,13 @@ recast@~0.11.12:
     private "~0.1.5"
     source-map "~0.5.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 rechoir@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.7.0.tgz#32650fd52c21ab252aa5d65b19310441c7e03aca"
@@ -10794,7 +10828,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.9.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -11085,10 +11119,27 @@ shell-quote@^1.6.1, shell-quote@^1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
+shelljs@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shiki@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.3.tgz#7bf7bcf3ed50ca525ec89cc09254abce4264d5ca"
+  integrity sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==
+  dependencies:
+    onigasm "^2.2.5"
+    vscode-textmate "^5.2.0"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -12085,6 +12136,35 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typedoc-default-themes@^0.12.10:
+  version "0.12.10"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz#614c4222fe642657f37693ea62cad4dafeddf843"
+  integrity sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==
+
+typedoc-plugin-markdown@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.7.2.tgz#87f3f13c074f4c67e1902063a1846c328d690069"
+  integrity sha512-SBGYKSJO48oGEXF9vC1ldcuqNyOC17st6LXy9/KMQ5tSGY0NRW8ldlBXI0PYrci+IbeXlkUfyhN0n3ud/2/VjQ==
+  dependencies:
+    handlebars "^4.7.7"
+
+typedoc@^0.20.36:
+  version "0.20.36"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.20.36.tgz#ee5523c32f566ad8283fc732aa8ea322d1a45f6a"
+  integrity sha512-qFU+DWMV/hifQ9ZAlTjdFO9wbUIHuUBpNXzv68ZyURAP9pInjZiO4+jCPeAzHVcaBCHER9WL/+YzzTt6ZlN/Nw==
+  dependencies:
+    colors "^1.4.0"
+    fs-extra "^9.1.0"
+    handlebars "^4.7.7"
+    lodash "^4.17.21"
+    lunr "^2.3.9"
+    marked "^2.0.3"
+    minimatch "^3.0.0"
+    progress "^2.0.3"
+    shelljs "^0.8.4"
+    shiki "^0.9.3"
+    typedoc-default-themes "^0.12.10"
+
 typescript@~4.1.3:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
@@ -12344,6 +12424,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vscode-textmate@^5.2.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.4.0.tgz#4b25ffc1f14ac3a90faf9a388c67a01d24257cd7"
+  integrity sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## References

- for #66 (just the typescript side of the house)

## Code changes

- adds `typedoc` with `typedoc-plugin-markdown`
- coverts raw typedoc markdown into something more myst-compatible
- generates a few intermediate pages for better structure
- adds a few nasty directives to the pyolite worker to appease whatever typedoc needs
- adds `pytest-check-links` to make sure we (or typedoc, or myst, or sphinx) don't break anything
  - runs in CI, adding about a minute to the end of the build
    - we _could_ run _a lot_ more things in parallel, e.g. `doit -n4 build lint test docs check`...
      - but then the logs become unreadable with everything interleaved
- skips `yarn install` if `.yarn-integrity` exists to get cache benefits (back)
- splits upgrading `pip` and `requirements.txt` to get cache benefits
- skips the vercel deploy, as my PR builds don't have `secrets.VERCEL_TOKEN`
- wraps first command in shutil which for #70
 
## User-facing changes

- typescript API docs (will eventually) appear on documentation site

![Screenshot from 2021-04-26 15-48-48](https://user-images.githubusercontent.com/45380/116141644-f3343900-a6a6-11eb-825c-3fa632517954.png)

## Backwards-incompatible changes

- n/a