### PR TITLE
Fix node dev server for unslashed endpoints, vanity try URLs on docs, fix binder

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -28,4 +28,5 @@ dependencies:
   - pydata-sphinx-theme
   - pytest-check-links
   - sphinx
+  - sphinxext-rediraffe
   ### DOCS ENV ###

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -5,11 +5,13 @@ channels:
   - conda-forge
 
 dependencies:
+  # build stuff
+  - black
+  - flit >=3.1
   # demo stuff
   - jupyter-server-proxy
   - jupyterlab >=3,<4
   - jupyterlab-classic
-  - git
   # extra docs tools
   - sphinx-autobuild
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ from the ground-up using JupyterLab components and plugins.
 JupyterLite works with both [JupyterLab](https://github.com/jupyterlab/jupyterlab) and
 [JupyterLab Classic](https://github.com/jtpio/jupyterlab-classic).
 
-### [Try it with JupyterLab!](https://jupyterlite.readthedocs.io/en/latest/_static/lab/index.html)
+### [Try it with JupyterLab!](https://jupyterlite.readthedocs.io/en/latest/try/lab)
 
 ![image](https://user-images.githubusercontent.com/591645/114009512-7fe79600-9863-11eb-9aac-3a9ef6345011.png)
 
-### [Try it with JupyterLab Classic!](https://jupyterlite.readthedocs.io/en/latest/_static/classic/index.html)
+### [Try it with JupyterLab Classic!](https://jupyterlite.readthedocs.io/en/latest/try/classic)
 
 ![image](https://user-images.githubusercontent.com/591645/114454062-78fdb200-9bda-11eb-9cda-4ee327dd1c77.png)
 

--- a/app/tree/index.html
+++ b/app/tree/index.html
@@ -6,7 +6,7 @@
       (function() {
         window.location.href = window.location.href.replace(
           /\/tree(\/|\/index.html)?$/,
-          '/../classic/tree/index.html'
+          '/classic/tree/index.html'
         );
       }.call(this));
     </script>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,12 +23,19 @@ version = ".".join(release.rsplit(".", 1))
 # sphinx config
 extensions = [
     "sphinx.ext.autosectionlabel",
+    "sphinxext.rediraffe",
     "myst_nb",
 ]
 
 autosectionlabel_prefix_document = True
 myst_heading_anchors = 3
 suppress_warnings = ["autosectionlabel.*"]
+
+rediraffe_redirects = {
+    "try/index": "_static/index",
+    "try/lab/index": "_static/lab/index",
+    "try/classic/index": "_static/classic/tree/index",
+}
 
 # files
 templates_path = ["_templates"]

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -21,4 +21,5 @@ dependencies:
   - pydata-sphinx-theme
   - pytest-check-links
   - sphinx
+  - sphinxext-rediraffe
   ### DOCS ENV ###

--- a/dodo.py
+++ b/dodo.py
@@ -298,9 +298,10 @@ class L:
         [*P.PACKAGE_JSONS, *P.APP_JSONS, P.ROOT_PACKAGE_JSON, *P.ROOT.glob("*.json")]
     )
     ALL_JS = [*(P.ROOT / "scripts").glob("*.js"), *(P.APP).glob("*/index.js")]
+    ALL_HTML = [(P.APP / "index.html"), *P.APP.glob("*/index.html")]
     ALL_MD = [*P.CI.rglob("*.md"), *P.DOCS_MD]
     ALL_YAML = [*P.ROOT.glob("*.yml"), *P.BINDER.glob("*.yml"), *P.CI.rglob("*.yml")]
-    ALL_PRETTIER = [*ALL_JSON, *ALL_MD, *ALL_YAML, *ALL_ESLINT, *ALL_JS]
+    ALL_PRETTIER = [*ALL_JSON, *ALL_MD, *ALL_YAML, *ALL_ESLINT, *ALL_JS, *ALL_HTML]
     ALL_BLACK = [
         *P.DOCS_PY,
         P.DODO,

--- a/dodo.py
+++ b/dodo.py
@@ -297,9 +297,10 @@ class L:
     ALL_JSON = set(
         [*P.PACKAGE_JSONS, *P.APP_JSONS, P.ROOT_PACKAGE_JSON, *P.ROOT.glob("*.json")]
     )
+    ALL_JS = [*(P.ROOT / "scripts").glob("*.js"), *(P.APP).glob("*/index.js")]
     ALL_MD = [*P.CI.rglob("*.md"), *P.DOCS_MD]
     ALL_YAML = [*P.ROOT.glob("*.yml"), *P.BINDER.glob("*.yml"), *P.CI.rglob("*.yml")]
-    ALL_PRETTIER = [*ALL_JSON, *ALL_MD, *ALL_YAML, *ALL_ESLINT]
+    ALL_PRETTIER = [*ALL_JSON, *ALL_MD, *ALL_YAML, *ALL_ESLINT, *ALL_JS]
     ALL_BLACK = [
         *P.DOCS_PY,
         P.DODO,

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,3 +5,4 @@ myst-nb
 pydata-sphinx-theme
 pytest-check-links
 sphinx
+sphinxext-rediraffe


### PR DESCRIPTION
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bollwyvl/jupyterlite/gh-73-fix-node-serving-classic?urlpath=lab)

## References

- fixes #73
- fixes #74
- fixes redirect in `/tree` when served under a non-`/`
- adds vanity redirects for `try(/lab|/classic)` -> `_static/(\1)index.html`

## Code changes

- convert `serve.js` to async
- clean up detecting directories for slashes
- adds `sphinx-rediraffe` for generating redirects (kinda broken in watch, don't care)

## User-facing changes

- slightly shorter URLs on docs

## Backwards-incompatible changes

- n/a