### PR TITLE
Add CI job to create GitHub releases and upload assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,3 +86,19 @@ jobs:
           if-no-files-found: ignore
           path: |
             /tmp/sphinx-*.log
+
+  release:
+    needs: [build]
+    # if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: jupyterlite dist ${{ github.run_number }}
+          path: ./dist
+      - name: Extract the app
+        run: |
+          tar -xvf ./dist/*.tgz
+      - name: tmp - list dir
+        run: |
+          tree .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*.*.*'
   pull_request:
     branches: '*'
 
@@ -89,16 +91,19 @@ jobs:
 
   release:
     needs: [build]
-    # if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2
         with:
           name: jupyterlite dist ${{ github.run_number }}
           path: ./dist
-      - name: Extract the app
-        run: |
-          tar -xvf ./dist/*.tgz
-      - name: tmp - list dir
-        run: |
-          tree .
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          prerelease: true
+          files: |
+            dist/jupyterlite-*.tgz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,6 @@ jobs:
           draft: true
           prerelease: true
           files: |
-            dist/jupyterlite-*.tgz
+            dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jtpio/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes #16 

Add a CI job to automatically create a GitHub release, and upload the content of the tarball as release assets.

This is a first step to make it easier for folks who want to deploy their own JupyterLite.

### TODO:

- [x] Add the `release` job to the existing `build` workflow
- [x] Trigger on `v*` tag
- [x] Create the release via the action with https://github.com/softprops/action-gh-release (https://github.com/actions/upload-release-asset is deprecated)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

CI

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
