### PR TITLE
Disable `nameFileOnSave` on the demo site

### DIFF
--- a/docs/overrides.json
+++ b/docs/overrides.json
@@ -13,5 +13,8 @@
         "options": {}
       }
     ]
+  },
+  "@jupyterlab/docmanager-extension:plugin": {
+    "nameFileOnSave": false
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jtpio/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

This dialog added in https://github.com/jupyterlab/jupyterlab/pull/10043 was shipped in a recent JupyterLab alpha release:

![image](https://user-images.githubusercontent.com/591645/120773035-3644c000-c521-11eb-8e1f-385e1ce8a0ac.png)

But there are still a couple of things to fix upstream.

Let's disable it for now on the demo site since it kind of gets in the way.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

No rename dialog on the demo site for now.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
