### PR TITLE
add chunkHashname with contenthash in webpack

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -225,6 +225,9 @@ module.exports = [
         }
       ]
     },
+    optimization: {
+      moduleIds: 'deterministic'
+    },
     plugins: [
       new webpack.DefinePlugin({
         // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -209,6 +209,7 @@ module.exports = [
         name: ['_JUPYTERLAB', 'CORE_OUTPUT']
       },
       filename: 'bundle.js',
+      chunkFilename: '[name].[contenthash].js',
       // to generate valid wheel names
       assetModuleFilename: '[name][ext][query]'
     },


### PR DESCRIPTION
## References

- a small part of #118
- probably needed for #137 to not be too crazy

## Code changes

- tweaks some webpack settings 

## User-facing changes

- should result in more reliable outputs resulting in fewer _odd_ cache situations

## Backwards-incompatible changes

- n/a

## future work

- the `bundle.js` is probably still a problem?
- it'll still take some doing to handle the multiple entrypoints correctly
 - when we get it squared away, we can also explore the `runtimeChunk` options to get better cache behavior
- we might need some more movement towards #104
- the _build-time_ `cache`, which I _haven't_ turned on is _pretty awesome_

```
webpack 5.37.1 compiled successfully in 1223 ms
lerna success run Ran npm script 'build:prod' in 1 package in 58.5s:
```
And then, subsequently:
```
webpack 5.37.1 compiled successfully in 423 ms
lerna success run Ran npm script 'build:prod' in 1 package in 6.5s:
```