### PR TITLE
Fix downloading from the filebrowser

### DIFF
--- a/app/lab/index.template.js
+++ b/app/lab/index.template.js
@@ -27,6 +27,7 @@ const disabled = [
   '@jupyterlab/application-extension:tree-resolver',
   '@jupyterlab/apputils-extension:resolver',
   '@jupyterlab/docmanager-extension:download',
+  '@jupyterlab/filebrowser-extension:download',
   '@jupyterlab/help-extension:about'
 ];
 

--- a/app/retro/index.template.js
+++ b/app/retro/index.template.js
@@ -108,7 +108,6 @@ async function main() {
         require('@jupyterlab/filebrowser-extension').default.filter(({ id }) =>
           [
             '@jupyterlab/filebrowser-extension:browser',
-            '@jupyterlab/filebrowser-extension:download',
             '@jupyterlab/filebrowser-extension:factory',
             '@jupyterlab/filebrowser-extension:file-upload-status',
             '@jupyterlab/filebrowser-extension:open-with',

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -41,10 +41,13 @@
     "@jupyterlab/apputils": "^3.1.0-alpha.11",
     "@jupyterlab/docmanager": "^3.1.0-alpha.11",
     "@jupyterlab/docprovider": "^3.1.0-alpha.11",
+    "@jupyterlab/filebrowser": "^3.1.0-alpha.11",
     "@jupyterlab/help-extension": "^3.1.0-alpha.11",
     "@jupyterlab/mainmenu": "^3.1.0-alpha.11",
+    "@jupyterlab/services": "^6.1.0-alpha.11",
     "@jupyterlab/translation": "^3.1.0-alpha.11",
     "@jupyterlite/ui-components": "^0.1.0-alpha.0",
+    "@lumino/algorithm": "^1.6.0",
     "@lumino/widgets": "^1.23.0"
   },
   "devDependencies": {

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -46,6 +46,7 @@
     "@jupyterlab/mainmenu": "^3.1.0-alpha.11",
     "@jupyterlab/services": "^6.1.0-alpha.11",
     "@jupyterlab/translation": "^3.1.0-alpha.11",
+    "@jupyterlab/ui-components": "^3.1.0-alpha.11",
     "@jupyterlite/ui-components": "^0.1.0-alpha.0",
     "@lumino/algorithm": "^1.6.0",
     "@lumino/widgets": "^1.23.0"

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -265,7 +265,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
               file.type === 'notebook' || file.mimetype.indexOf('json') !== -1
                 ? JSON.stringify(file.content, null, 2)
                 : file.content;
-            downloadContent(formatted, item.path);
+            downloadContent(formatted, item.name);
           });
         },
         icon: downloadIcon.bindprops({ stylesheet: 'menuItem' }),

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -261,7 +261,11 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
               return;
             }
             const file = await contents.get(item.path, { content: true });
-            downloadContent(JSON.stringify(file.content), item.path);
+            const formatted =
+              file.type === 'notebook' || file.mimetype.indexOf('json') !== -1
+                ? JSON.stringify(file.content, null, 2)
+                : file.content;
+            downloadContent(formatted, item.path);
           });
         },
         icon: downloadIcon.bindprops({ stylesheet: 'menuItem' }),

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -260,8 +260,8 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
             if (item.type === 'directory') {
               return;
             }
-            const file = await contents.get(item.path);
-            downloadContent(file.content, item.path);
+            const file = await contents.get(item.path, { content: true });
+            downloadContent(JSON.stringify(file.content), item.path);
           });
         },
         icon: downloadIcon.bindprops({ stylesheet: 'menuItem' }),


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jtpio/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes #125 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Provide an alternative implementation for the `@jupyterlab/filebrowser-extension:download` plugin to be able to download files from the filebrowser context menu.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

The download entry in the file browser should now work:

![image](https://user-images.githubusercontent.com/591645/121931668-33797480-cd44-11eb-953f-e27fae0a4d58.png)

It should also work for multiple files.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
