### PR TITLE
Split up CI into multiple jobs, test on more platforms

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -42,7 +42,6 @@ dependencies:
   - pytest-check-links
   # test
   - ansi2html
-  - hypothesis-jsonschema
   - pytest-console-scripts
   - pytest-cov
   - pytest-html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Setup pip (base)
+        run: pip install -U pip setuptools wheel
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
+      - name: Setup pip (build)
+        run: pip install -r requirements-build.txt
       - name: Install node
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
       - name: Cache node modules
         uses: actions/cache@v2
         id: cache-node-modules
@@ -43,17 +54,6 @@ jobs:
             ${{ env.CACHE_EPOCH }}-yarn-packages-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-yarn-packages-
-      - name: Setup pip (base)
-        run: pip install -U pip setuptools wheel
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
-          restore-keys: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
-      - name: Setup pip (build)
-        run: pip install -r requirements-build.txt
       - name: Install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: doit setup:js
@@ -75,13 +75,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Setup pip (base)
+        run: pip install -U pip setuptools wheel
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
+      - name: Setup pip (lint)
+        run: pip install -r requirements-lint.txt
       - name: Install node
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
       - name: Cache node modules
         uses: actions/cache@v2
         id: cache-node-modules
@@ -99,17 +110,6 @@ jobs:
             ${{ env.CACHE_EPOCH }}-yarn-packages-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-yarn-packages-
-      - name: Setup pip (base)
-        run: pip install -U pip setuptools wheel
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
-          restore-keys: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
-      - name: Setup pip (lint)
-        run: pip install -r requirements-lint.txt
       - name: Install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: doit setup:js
@@ -184,6 +184,30 @@ jobs:
         with:
           name: jupyterlite dist ${{ github.run_number }}
           path: ./dist
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Cache node modules
+        uses: actions/cache@v2
+        id: cache-node-modules
+        with:
+          path: node_modules/
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: Cache yarn packages
+        uses: actions/cache@v2
+        id: cache-yarn-packages
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        with:
+          path: .yarn-packages
+          key: |
+            ${{ env.CACHE_EPOCH }}-yarn-packages-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ env.CACHE_EPOCH }}-yarn-packages-
+      - name: Install
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: doit setup:js
       - name: Docs
         run: doit docs
       - name: Check Built Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      BUILDING_IN_CI: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -68,6 +70,8 @@ jobs:
   lint:
     needs: [build]
     runs-on: ubuntu-latest
+    env:
+      LINTING_IN_CI: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -111,14 +115,14 @@ jobs:
         run: doit setup:js
       - name: Lint
         run: doit lint
-      - name: Schema
-        run: doit schema
       - name: Test (js)
         run: doit test:js
 
   test:
     needs: [build]
     runs-on: ${{ matrix.os }}-latest
+    env:
+      TESTING_IN_CI: 1
     strategy:
       matrix:
         os: [ubuntu, windows, macos]
@@ -159,6 +163,8 @@ jobs:
   docs:
     needs: [build]
     runs-on: ubuntu-latest
+    env:
+      DOCS_IN_CI: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: doit setup:js
       - name: Build
-        run: doit build
+        run: doit -n4 build || doit build
       - name: Dist
         run: doit dist
       - name: Upload (dist)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           name: jupyterlite dist ${{ github.run_number }}
           path: ./dist
 
-  lint:
+  lint-js-test:
     runs-on: ubuntu-latest
     env:
       LINTING_IN_CI: 1
@@ -116,10 +116,10 @@ jobs:
       - name: Install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: doit setup:js
-      - name: Lint
-        run: doit lint
       - name: Test (js)
         run: doit test:js
+      - name: Lint
+        run: doit lint
 
   test:
     needs: [build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
-      - name: Setup pip (build)
+      - name: Setup pip (lint)
         run: pip install -r requirements-lint.txt
       - name: Install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,6 +169,13 @@ jobs:
           path: ./dist
       - name: Test (py)
         run: doit test:py:*
+      - name: Upload (reports)
+        uses: actions/upload-artifact@v2
+        with:
+          name: jupyterlite reports ${{ github.run_number }} ${{ matrix.os }}
+          path: |
+            build/htmlcov
+            build/pytest
 
   docs:
     needs: [build, lint-js-test]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: jupyterlite typedoc ${{ github.run_number }}
-          path: ./build/typedoc
+          path: ./docs/api/ts
 
   test:
     needs: [build]
@@ -187,7 +187,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: jupyterlite typedoc ${{ github.run_number }}
-          path: ./build/typedoc
+          path: ./docs/api/ts
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,6 @@ jobs:
           path: ./dist
 
   lint:
-    needs: [build]
     runs-on: ubuntu-latest
     env:
       LINTING_IN_CI: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,13 @@ jobs:
         run: doit test:js
       - name: Lint
         run: doit lint
+      - name: Docs (typedoc)
+        run: doit typedoc:mystify
+      - name: Upload (typedoc)
+        uses: actions/upload-artifact@v2
+        with:
+          name: jupyterlite typedoc ${{ github.run_number }}
+          path: ./build/typedoc
 
   test:
     needs: [build]
@@ -155,7 +162,8 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Setup pip (test)
         run: pip install -r requirements-test.txt
-      - uses: actions/download-artifact@v2
+      - name: Download (dist)
+        uses: actions/download-artifact@v2
         with:
           name: jupyterlite dist ${{ github.run_number }}
           path: ./dist
@@ -163,13 +171,23 @@ jobs:
         run: doit test:py:*
 
   docs:
-    needs: [build]
+    needs: [build, lint-js-test]
     runs-on: ubuntu-latest
     env:
       DOCS_IN_CI: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Download (dist)
+        uses: actions/download-artifact@v2
+        with:
+          name: jupyterlite dist ${{ github.run_number }}
+          path: ./dist
+      - name: Download (typedoc)
+        uses: actions/download-artifact@v2
+        with:
+          name: jupyterlite typedoc ${{ github.run_number }}
+          path: ./typedoc
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
@@ -185,36 +203,8 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Setup pip (docs)
         run: pip install -r requirements-docs.txt
-      - uses: actions/download-artifact@v2
-        with:
-          name: jupyterlite dist ${{ github.run_number }}
-          path: ./dist
-      - name: Install node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - name: Cache (node_modules)
-        uses: actions/cache@v2
-        id: cache-node-modules
-        with:
-          path: node_modules/
-          key: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-      - name: Cache (.yarn-packages)
-        uses: actions/cache@v2
-        id: cache-yarn-packages
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        with:
-          path: .yarn-packages
-          key: |
-            ${{ env.CACHE_EPOCH }}-yarn-packages-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ env.CACHE_EPOCH }}-yarn-packages-
-      - name: Install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: doit setup:js
       - name: Docs
-        run: doit docs
+        run: doit docs:sphinx
       - name: Check Built Artifacts
         run: doit check
       - name: Upload Sphinx Logs
@@ -229,7 +219,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - name: Download (dist)
+        uses: actions/download-artifact@v2
         with:
           name: jupyterlite dist ${{ github.run_number }}
           path: ./dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,8 +139,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Cache yarn packages
-        uses: actions/cache@v2
       - name: Setup pip (base)
         run: |
           pip install -U pip setuptools wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     tags:
-      - 'v*.*.*'
+      - v*.*.*
   pull_request:
     branches: '*'
 
@@ -20,15 +20,15 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: 14.x
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: 3.8
       - name: Cache node modules
         uses: actions/cache@v2
         id: cache-node-modules
         with:
-          path: 'node_modules/'
+          path: node_modules/
           key: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
       - name: Cache yarn packages
@@ -36,14 +36,13 @@ jobs:
         id: cache-yarn-packages
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         with:
-          path: '.yarn-packages'
+          path: .yarn-packages
           key: |
             ${{ env.CACHE_EPOCH }}-yarn-packages-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-yarn-packages-
-      - name: Setup pip (pip)
-        run: |
-          pip install -U pip setuptools wheel
+      - name: Setup pip (base)
+        run: pip install -U pip setuptools wheel
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
@@ -51,46 +50,146 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
-      - name: Setup pip (dependecies)
-        run: |
-          pip install -r requirements-docs.txt
+      - name: Setup pip (build)
+        run: pip install -r requirements-build.txt
       - name: Install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: |
-          doit setup:js
+        run: doit setup:js
       - name: Build
-        run: |
-          doit build
+        run: doit build
       - name: Dist
-        run: |
-          doit dist
+        run: doit dist
       - name: Upload (dist)
         uses: actions/upload-artifact@v2
         with:
           name: jupyterlite dist ${{ github.run_number }}
           path: ./dist
+
+  lint:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Cache node modules
+        uses: actions/cache@v2
+        id: cache-node-modules
+        with:
+          path: node_modules/
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: Cache yarn packages
+        uses: actions/cache@v2
+        id: cache-yarn-packages
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        with:
+          path: .yarn-packages
+          key: |
+            ${{ env.CACHE_EPOCH }}-yarn-packages-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ env.CACHE_EPOCH }}-yarn-packages-
+      - name: Setup pip (base)
+        run: pip install -U pip setuptools wheel
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
+      - name: Setup pip (build)
+        run: pip install -r requirements-lint.txt
+      - name: Install
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: doit setup:js
       - name: Lint
-        run: |
-          doit lint
+        run: doit lint
       - name: Schema
+        run: doit schema
+      - name: Test (js)
+        run: doit test:js
+
+  test:
+    needs: [build]
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [ubuntu, windows, macos]
+        include:
+          - os: ubuntu
+            pip-cache: ~/.cache/pip
+          - os: macos
+            pip-cache: ~/Library/Caches/pip
+          - os: windows
+            pip-cache: ~\AppData\Local\pip\Cache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Cache yarn packages
+        uses: actions/cache@v2
+      - name: Setup pip (base)
         run: |
-          doit schema
-      - name: Test
-        run: |
-          doit test
+          pip install -U pip setuptools wheel
+      - uses: actions/cache@v2
+        with:
+          path: ${{ matrix.pip-cache }}
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
+      - name: Setup pip (test)
+        run: pip install -r requirements-test.txt
+      - uses: actions/download-artifact@v2
+        with:
+          name: jupyterlite dist ${{ github.run_number }}
+          path: ./dist
+      - name: Test (py)
+        run: doit test:py:*
+
+  docs:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Setup pip (base)
+        run: pip install -U pip setuptools wheel
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
+      - name: Setup pip (docs)
+        run: pip install -r requirements-docs.txt
+      - uses: actions/download-artifact@v2
+        with:
+          name: jupyterlite dist ${{ github.run_number }}
+          path: ./dist
       - name: Docs
-        run: |
-          doit docs
+        run: doit docs
       - name: Check Built Artifacts
-        run: |
-          doit check
+        run: doit check
       - name: Upload Sphinx Logs
         if: always()
         uses: actions/upload-artifact@v2
         with:
           if-no-files-found: ignore
-          path: |
-            /tmp/sphinx-*.log
+          path: /tmp/sphinx-*.log
 
   release:
     needs: [build]
@@ -106,7 +205,6 @@ jobs:
         with:
           draft: true
           prerelease: true
-          files: |
-            dist/*
+          files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
           python-version: 3.8
       - name: Setup pip (base)
         run: pip install -U pip setuptools wheel
-      - uses: actions/cache@v2
+      - name: Cache (pip)
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: |
@@ -37,14 +38,14 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-      - name: Cache node modules
+      - name: Cache (node_modules)
         uses: actions/cache@v2
         id: cache-node-modules
         with:
           path: node_modules/
           key: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-      - name: Cache yarn packages
+      - name: Cache (.yarn-packages)
         uses: actions/cache@v2
         id: cache-yarn-packages
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -81,7 +82,8 @@ jobs:
           python-version: 3.8
       - name: Setup pip (base)
         run: pip install -U pip setuptools wheel
-      - uses: actions/cache@v2
+      - name: Cache (pip)
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: |
@@ -94,14 +96,14 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-      - name: Cache node modules
+      - name: Cache (node_modules)
         uses: actions/cache@v2
         id: cache-node-modules
         with:
           path: node_modules/
           key: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-      - name: Cache yarn packages
+      - name: Cache (.yarn-packages)
         uses: actions/cache@v2
         id: cache-yarn-packages
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -143,7 +145,8 @@ jobs:
       - name: Setup pip (base)
         run: |
           pip install -U pip setuptools wheel
-      - uses: actions/cache@v2
+      - name: Cache (pip)
+        uses: actions/cache@v2
         with:
           path: ${{ matrix.pip-cache }}
           key: |
@@ -172,7 +175,8 @@ jobs:
           python-version: 3.8
       - name: Setup pip (base)
         run: pip install -U pip setuptools wheel
-      - uses: actions/cache@v2
+      - name: Cache (pip)
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: |
@@ -189,14 +193,14 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-      - name: Cache node modules
+      - name: Cache (node_modules)
         uses: actions/cache@v2
         id: cache-node-modules
         with:
           path: node_modules/
           key: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-      - name: Cache yarn packages
+      - name: Cache (.yarn-packages)
         uses: actions/cache@v2
         id: cache-yarn-packages
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,11 +117,11 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: doit setup:js
       - name: Test (js)
-        run: doit test:js
+        run: doit -n4 test:js
       - name: Lint
         run: doit lint
       - name: Docs (typedoc)
-        run: doit typedoc:mystify
+        run: doit -n4 docs:typedoc:mystify
       - name: Upload (typedoc)
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: jupyterlite typedoc ${{ github.run_number }}
-          path: ./typedoc
+          path: ./build/typedoc
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,10 @@ jobs:
       - name: Install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: doit setup:js
-      - name: Build
-        run: doit -n4 build || doit build
+      - name: Build (js)
+        run: doit -n4 build:js* || doit build:js*
+      - name: Build (py)
+        run: doit -n4 build:py*
       - name: Dist
         run: doit dist
       - name: Upload (dist)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -30,7 +30,6 @@ dependencies:
   - pytest-check-links
   # test
   - ansi2html
-  - hypothesis-jsonschema
   - pytest-console-scripts
   - pytest-cov
   - pytest-html

--- a/dodo.py
+++ b/dodo.py
@@ -469,6 +469,7 @@ def task_test():
         return
 
     pytest_args = [
+        *C.PYM,
         "pytest",
         "--ff",
         "--script-launch-mode=subprocess",
@@ -490,6 +491,13 @@ def task_test():
         cov_index = cov_path / "index.html"
         html_index = B.BUILD / f"pytest/{py_name}/index.html"
 
+        if C.CI:
+            cwd = B.DIST
+            pkg_args = ["-m", py_mod]
+        else:
+            cwd = setup_py.parent
+            pkg_args = []
+
         yield U.ok(
             B.OK_LITE_PYTEST,
             name=f"py:{py_name}",
@@ -503,6 +511,7 @@ def task_test():
             actions=[
                 U.do(
                     *pytest_args,
+                    *pkg_args,
                     *(C.PYTEST_ARGS or []),
                     "--cov",
                     py_mod,
@@ -510,7 +519,7 @@ def task_test():
                     f"html:{cov_path}",
                     f"--html={html_index}",
                     "--self-contained-html",
-                    cwd=setup_py.parent,
+                    cwd=cwd,
                 )
             ],
         )

--- a/dodo.py
+++ b/dodo.py
@@ -493,7 +493,7 @@ def task_test():
 
         if C.CI:
             cwd = B.DIST
-            pkg_args = ["-m", py_mod]
+            pkg_args = ["--pyargs", py_mod]
         else:
             cwd = setup_py.parent
             pkg_args = []

--- a/dodo.py
+++ b/dodo.py
@@ -88,7 +88,7 @@ def task_lint():
         name="pyflakes",
         doc="ensure python code style with pyflakes",
         file_dep=[*L.ALL_BLACK, B.OK_BLACK],
-        actions=[U.do("pyflakes", *L.ALL_BLACK)],
+        actions=[U.do(*C.PYM, "pyflakes", *L.ALL_BLACK)],
     )
 
     yield dict(
@@ -511,7 +511,6 @@ def task_test():
             actions=[
                 U.do(
                     *pytest_args,
-                    *pkg_args,
                     *(C.PYTEST_ARGS or []),
                     "--cov",
                     py_mod,
@@ -519,6 +518,7 @@ def task_test():
                     f"html:{cov_path}",
                     f"--html={html_index}",
                     "--self-contained-html",
+                    *pkg_args,
                     cwd=cwd,
                 )
             ],

--- a/dodo.py
+++ b/dodo.py
@@ -459,7 +459,7 @@ def task_watch():
 
 def task_test():
     """test jupyterlite"""
-    if C.LINTING_IN_CI or C.DOCS_IN_CI or C.BUILDING_IN_CI:
+    if C.DOCS_IN_CI or C.BUILDING_IN_CI:
         return
 
     yield U.ok(
@@ -469,6 +469,9 @@ def task_test():
         file_dep=[B.YARN_INTEGRITY, B.META_BUILDINFO],
         actions=[U.do("yarn", "build:test"), U.do("yarn", "test")],
     )
+
+    if C.LINTING_IN_CI:
+        return
 
     pytest_args = [
         "pytest",

--- a/dodo.py
+++ b/dodo.py
@@ -361,7 +361,7 @@ def task_docs():
         task_dep=[f"dev:py:{C.NAME}"],
         actions=[(U.docs_app, [])],
         file_dep=[
-            B.PY_APP_PACK,
+            *([] if C.CI else [B.PY_APP_PACK]),
             *P.ALL_EXAMPLES,
             # NOTE: these won't always trigger a rebuild because of the inner dodo
             *P.PY_SETUP_PY[C.NAME].rglob("*.py"),

--- a/dodo.py
+++ b/dodo.py
@@ -10,7 +10,6 @@ from hashlib import sha256
 from pathlib import Path
 
 import doit
-import jsonschema
 
 
 def task_env():
@@ -851,6 +850,8 @@ class U:
 
     @staticmethod
     def validate(schema_path, instance_path=None, instance_obj=None, ref=None):
+        import jsonschema
+
         schema = json.loads(schema_path.read_text(**C.ENC))
         if ref:
             schema["$ref"] = ref

--- a/dodo.py
+++ b/dodo.py
@@ -107,7 +107,7 @@ def task_lint():
 
 def task_build():
     """build code and intermediate packages"""
-    if C.TESTING_IN_CI:
+    if C.TESTING_IN_CI or C.DOCS_IN_CI:
         return
 
     if not (C.RTD or C.CI):
@@ -193,9 +193,6 @@ def task_build():
 
     app_deps = [B.META_BUILDINFO, P.WEBPACK_CONFIG, P.LITE_ICON, P.LITE_WORDMARK]
     all_app_targets = []
-
-    if C.DOCS_IN_CI:
-        return
 
     for app_json in P.APP_JSONS:
         app = app_json.parent
@@ -333,7 +330,7 @@ def task_dev():
 
 def task_docs():
     """build documentation"""
-    if C.LINTING_IN_CI or C.TESTING_IN_CI or C.BUILDING_IN_CI:
+    if C.TESTING_IN_CI or C.BUILDING_IN_CI:
         return
 
     yield dict(

--- a/dodo.py
+++ b/dodo.py
@@ -333,27 +333,28 @@ def task_docs():
     if C.TESTING_IN_CI or C.BUILDING_IN_CI:
         return
 
-    yield dict(
-        name="typedoc:ensure",
-        file_dep=[*P.PACKAGE_JSONS],
-        actions=[U.typedoc_conf],
-        targets=[P.TYPEDOC_JSON, P.TSCONFIG_TYPEDOC],
-    )
-    yield dict(
-        name="typedoc:build",
-        doc="build the TS API documentation with typedoc",
-        file_dep=[B.META_BUILDINFO, *P.TYPEDOC_CONF],
-        actions=[U.do("yarn", "docs")],
-        targets=[B.DOCS_RAW_TYPEDOC_README],
-    )
+    if not C.DOCS_IN_CI:
+        yield dict(
+            name="typedoc:ensure",
+            file_dep=[*P.PACKAGE_JSONS],
+            actions=[U.typedoc_conf],
+            targets=[P.TYPEDOC_JSON, P.TSCONFIG_TYPEDOC],
+        )
+        yield dict(
+            name="typedoc:build",
+            doc="build the TS API documentation with typedoc",
+            file_dep=[B.META_BUILDINFO, *P.TYPEDOC_CONF],
+            actions=[U.do("yarn", "docs")],
+            targets=[B.DOCS_RAW_TYPEDOC_README],
+        )
 
-    yield dict(
-        name="typedoc:mystify",
-        doc="transform raw typedoc into myst markdown",
-        file_dep=[B.DOCS_RAW_TYPEDOC_README],
-        targets=[B.DOCS_TS_MYST_INDEX, *B.DOCS_TS_MODULES],
-        actions=[U.mystify, U.do("yarn", "prettier")],
-    )
+        yield dict(
+            name="typedoc:mystify",
+            doc="transform raw typedoc into myst markdown",
+            file_dep=[B.DOCS_RAW_TYPEDOC_README],
+            targets=[B.DOCS_TS_MYST_INDEX, *B.DOCS_TS_MODULES],
+            actions=[U.mystify, U.do("yarn", "prettier")],
+        )
 
     yield dict(
         name="app:build",

--- a/dodo.py
+++ b/dodo.py
@@ -686,7 +686,7 @@ class B:
     BUILD = P.ROOT / "build"
     DIST = P.ROOT / "dist"
     APP_PACK = DIST / f"""{C.NAME}-app-{D.APP_VERSION}.tgz"""
-    PY_APP_PACK = P.ROOT / C.NAME / "src" / C.NAME / APP_PACK.name
+    PY_APP_PACK = P.ROOT / "py" / C.NAME / "src" / C.NAME / APP_PACK.name
 
     DOCS_APP = BUILD / "docs-app"
     DOCS_APP_SHA256SUMS = DOCS_APP / "SHA256SUMS"

--- a/dodo.py
+++ b/dodo.py
@@ -272,8 +272,7 @@ def task_build():
         if py_name == C.NAME:
             dest = py_pkg / "src" / py_name / B.APP_PACK.name
             actions = [
-                lambda: [dest.exists() and dest.unlink(), None][-1],
-                lambda: [shutil.copy2(B.APP_PACK, dest), None][-1],
+                (U.copy_one, [B.APP_PACK, dest]),
                 *actions,
             ]
             file_dep += [B.APP_PACK, pyproj_toml]
@@ -959,7 +958,7 @@ class U:
     def build_one_flit(py_pkg):
         """attempt to build one package with flit: on RTD, allow doing a build in /tmp"""
 
-        print(f"[{py_pkg.name}] trying in-tree build..", flush=True)
+        print(f"[{py_pkg.name}] trying in-tree build...", flush=True)
         args = ["flit", "--debug", "build"]
 
         try:

--- a/dodo.py
+++ b/dodo.py
@@ -716,12 +716,16 @@ class U:
     def do(*args, cwd=P.ROOT, **kwargs):
         """wrap a CmdAction for consistency"""
         cmd = args[0]
-        cmd = Path(
-            shutil.which(cmd)
-            or shutil.which(f"{cmd}.exe")
-            or shutil.which(f"{cmd}.cmd")
-            or shutil.which(f"{cmd}.bat")
-        ).resolve()
+        try:
+            cmd = Path(
+                shutil.which(cmd)
+                or shutil.which(f"{cmd}.exe")
+                or shutil.which(f"{cmd}.cmd")
+                or shutil.which(f"{cmd}.bat")
+            ).resolve()
+        except Exception as err:
+            print(cmd, "is not available (this might not be a problem)")
+            return ["echo", f"{cmd} not available"]
         cmd_class = doit.tools.Interactive
         if C.RTD:
             cmd_class = doit.action.CmdAction

--- a/dodo.py
+++ b/dodo.py
@@ -533,7 +533,7 @@ class C:
     COV_THRESHOLD = 88
 
     BUILDING_IN_CI = json.loads(os.environ.get("BUILDING_IN_CI", "0"))
-    DOCS_IN_CI = json.loads(os.environ.get("TESTING_IN_CI", "0"))
+    DOCS_IN_CI = json.loads(os.environ.get("DOCS_IN_CI", "0"))
     LINTING_IN_CI = json.loads(os.environ.get("LINTING_IN_CI", "0"))
     TESTING_IN_CI = json.loads(os.environ.get("TESTING_IN_CI", "0"))
 

--- a/dodo.py
+++ b/dodo.py
@@ -547,6 +547,11 @@ class C:
 
     PYM = [sys.executable, "-m"]
     FLIT = [*PYM, "flit"]
+    SOURCE_DATE_EPOCH = (
+        subprocess.check_output(["git", "log", "-1", "--format=%ct"])
+        .decode("utf-8")
+        .strip()
+    )
 
 
 class P:
@@ -974,9 +979,10 @@ class U:
 
         print(f"[{py_pkg.name}] trying in-tree build...", flush=True)
         args = [*C.FLIT, "--debug", "build"]
+        env = os.environ.update(SOURCE_DATE_EPOCH=C.SOURCE_DATE_EPOCH)
 
         try:
-            subprocess.check_call(args, cwd=str(py_pkg))
+            subprocess.check_call(args, cwd=str(py_pkg), env=env)
         except subprocess.CalledProcessError:
             if not C.RTD:
                 print(f"[{py_pkg.name}] ... in-tree build failed, not on ReadTheDocs")
@@ -993,7 +999,7 @@ class U:
                 tdp = Path(td)
                 py_tmp = tdp / py_pkg.name
                 shutil.copytree(py_pkg, py_tmp)
-                subprocess.call(args, cwd=str(py_tmp))
+                subprocess.call(args, cwd=str(py_tmp), env=env)
                 shutil.copytree(py_tmp / "dist", py_dist)
 
 

--- a/dodo.py
+++ b/dodo.py
@@ -936,6 +936,7 @@ class U:
         for p in path.glob("*"):
             if p.name == "SHA256SUMS":
                 continue
+            print(p.stat().st_size / (1024 * 1024), "Mb", p.name)
             lines += ["  ".join([sha256(p.read_bytes()).hexdigest(), p.name])]
 
         output = "\n".join(lines)

--- a/dodo.py
+++ b/dodo.py
@@ -107,7 +107,7 @@ def task_lint():
 
 def task_build():
     """build code and intermediate packages"""
-    if C.TESTING_IN_CI or C.DOCS_IN_CI:
+    if C.TESTING_IN_CI:
         return
 
     if not (C.RTD or C.CI):
@@ -193,6 +193,9 @@ def task_build():
 
     app_deps = [B.META_BUILDINFO, P.WEBPACK_CONFIG, P.LITE_ICON, P.LITE_WORDMARK]
     all_app_targets = []
+
+    if C.DOCS_IN_CI:
+        return
 
     for app_json in P.APP_JSONS:
         app = app_json.parent

--- a/dodo.py
+++ b/dodo.py
@@ -110,10 +110,9 @@ def task_build():
     if C.TESTING_IN_CI or C.DOCS_IN_CI:
         return
 
-    # this doesn't appear to be reproducible vs. whatever is on RTD, making flit angry
-    if not C.RTD:
+    if not (C.RTD or C.CI):
         yield dict(
-            name="favicon",
+            name="docs:favicon",
             doc="rebuild favicons from svg source, requires imagemagick",
             file_dep=[P.DOCS_ICON],
             targets=[P.LAB_FAVICON],
@@ -143,7 +142,7 @@ def task_build():
         )
 
     yield dict(
-        name="ui-components",
+        name="js:ui-components",
         doc="copy the icon and wordmark to the ui-components package",
         file_dep=[P.DOCS_ICON, P.DOCS_WORDMARK, B.YARN_INTEGRITY],
         targets=[P.LITE_ICON, P.LITE_WORDMARK],

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -18,9 +18,13 @@ requires = [
 [tool.flit.scripts]
 jupyter-lite = "jupyterlite.app:main"
 
+[tool.flit.sdist]
+include = [
+    "src/jupyterlite/jupyterlite-*.tgz",
+]
+
 [tool.flit.metadata.requires-extra]
 test = [
-    "hypothesis-jsonschema",
     "pytest-cov",
     "pytest-html",
     "pytest-xdist",

--- a/py/jupyterlite/src/jupyterlite/constants.py
+++ b/py/jupyterlite/src/jupyterlite/constants.py
@@ -7,7 +7,7 @@ C_LOCALE = "C"
 ROOT = Path(__file__).parent
 
 #: all of the archives
-ALL_APP_ARCHIVES = sorted(ROOT.glob("jupyterlite-app-*.tgz"))
+ALL_APP_ARCHIVES = sorted(ROOT.glob("jupyterlite-*.tgz"))
 
 #: our baseline archive.
 DEFAULT_APP_ARCHIVE = ALL_APP_ARCHIVES[-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+known_first_party = [
+    "jupyterlite",
+]

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,4 @@
+# minimum needed to build jupyterlite... in addition to nodejs and yarn
+# see .binder/ and docs/ for full development/docs environments
+doit >=0.33,<0.34
+flit >=3.1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 # minimum needed to build jupyterlite docs... in addition to nodejs and yarn
 # see .binder/ and docs/ for full development/docs environments
--r requirements.txt
+-r requirements-build.txt
 
 # build
 sphinx
@@ -13,11 +13,5 @@ sphinx-autodoc-typehints
 # check
 pytest-check-links
 
-# test
-ansi2html
+# extras
 diffoscope
-hypothesis-jsonschema
-pytest-console-scripts
-pytest-cov
-pytest-html
-pytest-xdist

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,8 +1,8 @@
 # minimum needed to build jupyterlite... in addition to nodejs and yarn
 # see .binder/ and docs/ for full development/docs environments
+-r requirements-build.txt
+
 black
-doit >=0.33,<0.34
-flit >=3.1
 isort
 jsonschema >=3
 pyflakes

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,10 @@
+# minimum needed to test jupyterlite
+# see .binder/ and docs/ for full development/docs environments
+-r requirements-build.txt
+
+ansi2html
+hypothesis-jsonschema
+pytest-console-scripts
+pytest-cov
+pytest-html
+pytest-xdist

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,6 @@ pytest-console-scripts
 pytest-cov
 pytest-html
 pytest-xdist
+
+# extras
+jupyter_server

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,6 @@
 -r requirements-build.txt
 
 ansi2html
-hypothesis-jsonschema
 pytest-console-scripts
 pytest-cov
 pytest-html


### PR DESCRIPTION
## References

- fixes #163

## Code changes

- [x] splits up the build job, to get to python testing on different platforms faster
  - all told, seems to shave about a minute of total CI (while testing more)
- [x] uploads test reports
- [x] uses `SOURCE_DATE_EPOCH` for builds
- [x] another pass over requirements, etc.

## User-facing changes

- n/a

## Backwards-incompatible changes

- n/a/