### PR TITLE
add --user for initial pip install in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Setup pip (base)
-        run: pip install -U pip setuptools wheel
+        run: pip install --user -U pip setuptools wheel
       - name: Cache (pip)
         uses: actions/cache@v2
         with:
@@ -81,7 +81,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Setup pip (base)
-        run: pip install -U pip setuptools wheel
+        run: pip install --user -U pip setuptools wheel
       - name: Cache (pip)
         uses: actions/cache@v2
         with:
@@ -151,7 +151,7 @@ jobs:
           python-version: 3.8
       - name: Setup pip (base)
         run: |
-          pip install -U pip setuptools wheel
+          pip install --user -U pip setuptools wheel
       - name: Cache (pip)
         uses: actions/cache@v2
         with:
@@ -199,7 +199,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Setup pip (base)
-        run: pip install -U pip setuptools wheel
+        run: pip install --user -U pip setuptools wheel
       - name: Cache (pip)
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## References

- fixes #174

## Code changes

- Per error message, add `--user` to initial `pip install`.
  - didn't have to do this for a few months, but :shrug:  

## User-facing changes

- n/a

## Backwards-incompatible changes

- n/a