### PR TITLE
Make the Changelog compatible with Jupyter Releaser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,6 @@
 # CHANGELOG
 
-## 0.1.0a1 (Unreleased)
-
-### `jupyter lite` CLI
-
-- [#147] adds initial CLI tooling for building and extending JupyterLite sites
-
-### pyolite
-
-- [#145] adds initial pyolite widgets support
-- [#129] adds initial pyolite plotly support
-
-[#129]: https://github.com/jtpio/jupyterlite/pull/145
-[#145]: https://github.com/jtpio/jupyterlite/pull/145
-[#147]: https://github.com/jtpio/jupyterlite/pull/147
+<!-- <START NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0a0
 
@@ -202,3 +189,5 @@
 [@RichardScottOZ](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlite+involves%3ARichardScottOZ+updated%3A2021-03-27..2021-06-02&type=Issues)
 |
 [@vercel](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlite+involves%3Avercel+updated%3A2021-03-27..2021-06-02&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jtpio/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Partially related to #121 

This adds the start and end markers to `CHANGELOG.md`, so we can start using the Jupyter Releaser at least to generated the changelog.

## Code changes

None

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
