### PR TITLE
Add JupyterLab Miami Nights theme to the demo site, fix theme unloading

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -56,6 +56,7 @@ dependencies:
   - jupyterlab-tour >=3.1.0
   - jupyterlab-fasta >=3,<4
   - jupyterlab-geojson >=3,<4
+  - jupyterlab_miami_nights
   - plotly >=5,<6
   - theme-darcula
   ### DOCS ENV ###

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -43,6 +43,7 @@ dependencies:
   - jupyterlab-tour >=3.1.0
   - jupyterlab-fasta >=3,<4
   - jupyterlab-geojson >=3,<4
+  - jupyterlab_miami_nights
   - plotly >=5,<6
   - theme-darcula
   ### DOCS ENV ###

--- a/packages/theme/src/manager.ts
+++ b/packages/theme/src/manager.ts
@@ -36,19 +36,10 @@ export class ThemeManager extends LabThemeManager {
         reject(`Stylesheet failed to load: ${href}`);
       });
 
-      this._link = link;
-      this._unloadCSS();
       document.body.appendChild(link);
+      this['_links'].push(link);
     });
   }
 
-  /**
-   * Unload the previous theme.
-   */
-  private _unloadCSS(): void {
-    this._link?.parentElement?.removeChild(this._link);
-  }
-
-  private _link: HTMLLinkElement | undefined = undefined;
   private _themesUrl = '';
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jtpio/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Add `jupyterlab_miami_nights` as a new theme on the RTD demo site.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

None

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

![image](https://user-images.githubusercontent.com/591645/123662395-b666f880-d835-11eb-9ae0-dad885cb2ee2.png)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
