### PR TITLE
Add `jsonschema` as dependency

### DIFF
--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.7"
 requires = [
     "doit",
     "entrypoints",
+    "jsonschema >=3.0.1",
     "jupyter_core >=4.7",
     # TODO: support wheels https://github.com/jtpio/jupyterlite/issues/151
     # "wheel",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jtpio/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Looks like it was missing when installing `jupyterlite` in a bare environment (without `jupyterlab` / `jupyterlab_server`).

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

None

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

`jupyter lite build` in a bare environment would not give an error.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
