### PR TITLE
improve python distribution artifacts

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - flit >=3.1
   - isort
   - pyflakes
+  - twine
   # demo stuff
   - jupyter-server-proxy
   - jupyterlab >=3.1.0a11,<4
@@ -25,9 +26,9 @@ dependencies:
   # build
   - doit >=0.33,<0.34
   - flit >=3.1
+  - jsonschema >=3
   - pip
   - wheel
-  - jsonschema >=3
   - yarn <2
   # cli
   - wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,8 +118,6 @@ jobs:
         run: doit setup:js
       - name: Test (js)
         run: doit -n4 test:js
-      - name: Check distributions
-        run: doit distcheck
       - name: Lint
         run: doit lint
       - name: Docs (typedoc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,23 +157,6 @@ jobs:
         with:
           name: jupyterlite dist ${{ github.run_number }}
           path: ./dist
-      - name: Install (py)
-        run: python3 -m pip install --find-links dist jupyterlite
-      - name: Prepare smoke test folder
-        shell: bash
-        run: mkdir -p build/smoke-test
-      - name: Test (CLI)
-        run: |
-          cd build/smoke-test
-          jupyter lite --version
-          jupyter lite --help
-          jupyter lite list
-          jupyter lite status
-          jupyter lite build
-          jupyter lite check
-          jupyter lite archive
-          jupyter lite status
-          jupyter lite list
       - name: Cache (pip)
         uses: actions/cache@v2
         with:
@@ -182,6 +165,25 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
+      - name: Install (py)
+        run: |
+          python3 -m pip install entrypoints doit jupyter_core
+          python3 -m pip install --find-links dist --no-index-url --ignore-installed jupyterlite
+      - name: Prepare smoke test folder
+        shell: bash
+        run: mkdir -p build/smoke-test
+      - name: Test (CLI)
+        run: |
+          cd build/smoke-test
+          jupyter lite --version || exit 1
+          jupyter lite --help || exit 1
+          jupyter lite list || exit 1
+          jupyter lite status || exit 1
+          jupyter lite build || exit 1
+          jupyter lite check || exit 1
+          jupyter lite archive || exit 1
+          jupyter lite status || exit 1
+          jupyter lite list || exit 1
       - name: Setup pip (test)
         run: pip install -r requirements-test.txt
       - name: Test (py)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,10 @@ jobs:
       - name: Prepare smoke test folder
         shell: bash
         run: mkdir -p build/smoke-test
+      - name: Get SOURCE_DATE_EPOCH
+        id: source-date
+        run: |
+          echo "::set-output name=epoch::$(git log -1 --format=%ct)"
       - name: Test (CLI)
         run: |
           cd build/smoke-test
@@ -181,9 +185,9 @@ jobs:
           jupyter lite status || exit 1
           jupyter lite build || exit 1
           jupyter lite check || exit 1
-          jupyter lite archive || exit 1
-          jupyter lite status || exit 1
+          jupyter lite archive --source-date-epoch ${{ steps.source-date.outputs.epoch }} || exit 1
           jupyter lite list || exit 1
+          jupyter lite status --debug || exit 1
       - name: Setup pip (test)
         run: python3 -m pip install -r requirements-test.txt
       - name: Test (py)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,8 @@ jobs:
         run: doit setup:js
       - name: Test (js)
         run: doit -n4 test:js
+      - name: Check distributions
+        run: doit distcheck
       - name: Lint
         run: doit lint
       - name: Docs (typedoc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Setup pip (base)
-        run: pip install --user -U pip setuptools wheel
+        run: python3 -m pip install --user -U pip setuptools wheel
       - name: Cache (pip)
         uses: actions/cache@v2
         with:
@@ -33,7 +33,7 @@ jobs:
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Setup pip (build)
-        run: pip install -r requirements-build.txt
+        run: python3 -m pip install -r requirements-build.txt
       - name: Install node
         uses: actions/setup-node@v2
         with:
@@ -81,7 +81,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Setup pip (base)
-        run: pip install --user -U pip setuptools wheel
+        run: python3 -m pip install --user -U pip setuptools wheel
       - name: Cache (pip)
         uses: actions/cache@v2
         with:
@@ -91,7 +91,7 @@ jobs:
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Setup pip (lint)
-        run: pip install -r requirements-lint.txt
+        run: python3 -m pip install -r requirements-lint.txt
       - name: Install node
         uses: actions/setup-node@v2
         with:
@@ -150,8 +150,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Setup pip (base)
-        run: |
-          python3 -m pip install --user -U pip setuptools wheel
+        run: python3 -m pip install --user -U pip setuptools wheel
       - name: Download (dist)
         uses: actions/download-artifact@v2
         with:
@@ -168,7 +167,8 @@ jobs:
       - name: Install (py)
         run: |
           python3 -m pip install entrypoints doit jupyter_core
-          python3 -m pip install --find-links dist --no-index-url --ignore-installed jupyterlite
+          python3 -m pip install --find-links dist --no-index jupyterlite
+          python3 -m pip check
       - name: Prepare smoke test folder
         shell: bash
         run: mkdir -p build/smoke-test
@@ -185,7 +185,7 @@ jobs:
           jupyter lite status || exit 1
           jupyter lite list || exit 1
       - name: Setup pip (test)
-        run: pip install -r requirements-test.txt
+        run: python3 -m pip install -r requirements-test.txt
       - name: Test (py)
         run: doit test:py:*
       - name: Upload (reports)
@@ -218,7 +218,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Setup pip (base)
-        run: pip install --user -U pip setuptools wheel
+        run: python3 -m pip install --user -U pip setuptools wheel
       - name: Cache (pip)
         uses: actions/cache@v2
         with:
@@ -228,7 +228,7 @@ jobs:
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Setup pip (docs)
-        run: pip install -r requirements-docs.txt
+        run: python3 -m pip install -r requirements-docs.txt
       - name: Docs
         run: doit docs:sphinx
       - name: Check Built Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,29 @@ jobs:
           python-version: 3.8
       - name: Setup pip (base)
         run: |
-          pip install --user -U pip setuptools wheel
+          python3 -m pip install --user -U pip setuptools wheel
+      - name: Download (dist)
+        uses: actions/download-artifact@v2
+        with:
+          name: jupyterlite dist ${{ github.run_number }}
+          path: ./dist
+      - name: Install (py)
+        run: python3 -m pip install --find-links dist jupyterlite
+      - name: Prepare smoke test folder
+        shell: bash
+        run: mkdir -p build/smoke-test
+      - name: Test (CLI)
+        run: |
+          cd build/smoke-test
+          jupyter lite --version
+          jupyter lite --help
+          jupyter lite list
+          jupyter lite status
+          jupyter lite build
+          jupyter lite check
+          jupyter lite archive
+          jupyter lite status
+          jupyter lite list
       - name: Cache (pip)
         uses: actions/cache@v2
         with:
@@ -162,11 +184,6 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Setup pip (test)
         run: pip install -r requirements-test.txt
-      - name: Download (dist)
-        uses: actions/download-artifact@v2
-        with:
-          name: jupyterlite dist ${{ github.run_number }}
-          path: ./dist
       - name: Test (py)
         run: doit test:py:*
       - name: Upload (reports)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,30 @@ JupyterLite works with both [JupyterLab](https://github.com/jupyterlab/jupyterla
 [retro-screenshot]:
   https://user-images.githubusercontent.com/591645/114454062-78fdb200-9bda-11eb-9cda-4ee327dd1c77.png
 
+## 🏗️ Build your own JupyterLite 🏗️
+
+Install `jupyterlite` from PyPI, which comes with the CLI and a pre-built, empty site
+archive.
+
+```bash
+pip install --pre jupyterlite
+```
+
+Use the [`jupyter lite` CLI][cli] to `build`, `check`, or create a reproducible,
+remixable `archive` of your site, then [deploy] your built site to any static host, such
+as GitHub Pages or ReadTheDocs.
+
+| `jupyter lite` | description                                         | extras                                |
+| -------------: | --------------------------------------------------- | ------------------------------------- |
+|         `init` | build an empty site from the bundled app archive    |                                       |
+|        `build` | add your own notebooks, labextensions, and settings | `jupyter_server` for indexing content |
+|        `serve` | try out your site locally                           |                                       |
+|        `check` | check your site's metadata                          | `jsonschema` for schema validation    |
+|      `archive` | create a single-file archive                        |                                       |
+
+[cli]: https://jupyterlite.readthedocs.io/en/latest/cli.html
+[deploy]: https://jupyterlite.readthedocs.io/en/latest/deploying.html
+
 ## Features
 
 > For more details, see the [JupyterLite documentation](https://jupyterlite.rtfd.io).
@@ -42,7 +66,8 @@ JupyterLite works with both [JupyterLab](https://github.com/jupyterlab/jupyterla
 - Basic session and kernel management to have multiple kernels running at the same time
 - Support for
   [Code Consoles](https://jupyterlab.readthedocs.io/en/stable/user/code_console.html)
-- Initial support for visualization libraries such as `matplotlib` and `altair`
+- Initial support for interactive visualization libraries such as `altair`, `bqplot`,
+  `ipywidgets`, `matplotlib`, and `plotly`
 
 ### Ease of Deployment
 
@@ -84,3 +109,7 @@ See also:
   literal notebooks
 - [Basthon](https://basthon.fr/about.html): A Jupyter notebook implementation using
   Pyodide
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -37,20 +37,22 @@ archive.
 python3 -m pip install --pre jupyterlite
 ```
 
-Use the [`jupyter lite` CLI][cli] to `build`, `check`, or create a reproducible,
-remixable `archive` of your site, then [deploy] your built site to any static host, such
-as GitHub Pages or ReadTheDocs.
+Use the [`jupyter lite` CLI][cli] to `build`, `check`, or create a [reproducible],
+remixable `archive` of your site, then [publish] your built site to any static host,
+such as GitHub Pages or ReadTheDocs.
 
 | `jupyter lite` | description                                         | extras                                |
 | -------------: | --------------------------------------------------- | ------------------------------------- |
 |         `init` | build an empty site from the bundled app archive    |                                       |
 |        `build` | add your own notebooks, labextensions, and settings | `jupyter_server` for indexing content |
-|        `serve` | try out your site locally                           |                                       |
+|        `serve` | try out your site locally                           | `tornado` for snappier serving        |
 |        `check` | check your site's metadata                          | `jsonschema` for schema validation    |
 |      `archive` | create a single-file archive                        |                                       |
 
 [cli]: https://jupyterlite.readthedocs.io/en/latest/cli.html
-[deploy]: https://jupyterlite.readthedocs.io/en/latest/deploying.html
+[publish]: https://jupyterlite.readthedocs.io/en/latest/deploying.html
+[reproducible]:
+  https://jupyterlite.readthedocs.io/en/latest/cli.html#reproducible-archives
 
 ## Features
 
@@ -59,22 +61,27 @@ as GitHub Pages or ReadTheDocs.
 ### Browser-based Interactive Computing
 
 - Python kernel backed by [Pyodide](https://pyodide.org) running in a Web Worker
-- JavaScript kernel running in an `IFrame`
-- Combine Offline Notebook storage in browser `localStorage` or `IndexDB` with example
-  files
+  - Initial support for interactive visualization libraries such as `altair`, `bqplot`,
+    `ipywidgets`, `matplotlib`, and `plotly`
+- JavaScript and [P5.js] kernels running in an `IFrame`
+- View hosted example Notebooks and other files, then edit, save, and download from the
+  browser's `IndexDB` (or `localStorage`)
 - Support for saving settings for JupyterLab/Lite core and federated extensions
 - Basic session and kernel management to have multiple kernels running at the same time
 - Support for
   [Code Consoles](https://jupyterlab.readthedocs.io/en/stable/user/code_console.html)
-- Initial support for interactive visualization libraries such as `altair`, `bqplot`,
-  `ipywidgets`, `matplotlib`, and `plotly`
+
+[p5.js]: https://p5js.org/
 
 ### Ease of Deployment
 
-- Served via well-cacheable, static HTTP(S), works on most static web hosts, and locally
+- Served via well-cacheable, static HTTP(S), locally or on most static web hosts
 - Embeddable within larger applications
 - Requires no dedicated _application server_ much less a container orchestrator
-- Fine-grained configurability of page settings, including reuse of federated extensions
+- Fine-grained [configurability] of page settings, including reuse of federated
+  extensions
+
+[configurability]: https://jupyterlite.readthedocs.io/en/latest/configuring.html
 
 ## Status
 
@@ -109,7 +116,3 @@ See also:
   literal notebooks
 - [Basthon](https://basthon.fr/about.html): A Jupyter notebook implementation using
   Pyodide
-
-```
-
-```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install `jupyterlite` from PyPI, which comes with the CLI and a pre-built, empty
 archive.
 
 ```bash
-python3 -m pip install --pre jupyterlite
+python -m pip install --pre jupyterlite
 ```
 
 Use the [`jupyter lite` CLI][cli] to `build`, `check`, or create a [reproducible],

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install `jupyterlite` from PyPI, which comes with the CLI and a pre-built, empty
 archive.
 
 ```bash
-pip install --pre jupyterlite
+python3 -m pip install --pre jupyterlite
 ```
 
 Use the [`jupyter lite` CLI][cli] to `build`, `check`, or create a reproducible,

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -26,7 +26,7 @@ integration with other Jupyter tools.
 To get the [Python CLI](./cli.ipynb) and [API](./api/index.md) from [PyPI]:
 
 ```bash
-pip install jupyterlite
+python3 -m pip install --pre jupyterlite
 # TODO: mamba install jupyterlite
 ```
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -26,7 +26,7 @@ integration with other Jupyter tools.
 To get the [Python CLI](./cli.ipynb) and [API](./api/index.md) from [PyPI]:
 
 ```bash
-python3 -m pip install --pre jupyterlite
+python -m pip install --pre jupyterlite
 # TODO: mamba install jupyterlite
 ```
 

--- a/dodo.py
+++ b/dodo.py
@@ -307,9 +307,6 @@ def task_dist():
         targets=[B.DIST / "SHA256SUMS"],
     )
 
-
-@doit.create_after("dist")
-def task_distcheck():
     for dist in [*B.DIST.glob("*.whl"), *B.DIST.glob("*.tar.gz")]:
         yield dict(
             name=f"twine:{dist.name}",

--- a/dodo.py
+++ b/dodo.py
@@ -243,10 +243,19 @@ def task_build():
     )
 
     yield dict(
-        name=f"py:{C.NAME}:pre",
+        name=f"py:{C.NAME}:pre:readme",
+        file_dep=[P.README],
+        targets=[P.PY_README],
+        actions=[(U.copy_one, [P.README, P.PY_README])],
+    )
+
+    yield dict(
+        name=f"py:{C.NAME}:pre:app",
         file_dep=[B.APP_PACK],
         targets=[B.PY_APP_PACK],
-        actions=[(U.copy_one, [B.APP_PACK, B.PY_APP_PACK])],
+        actions=[
+            (U.copy_one, [B.APP_PACK, B.PY_APP_PACK]),
+        ],
     )
 
     for py_name, setup_py in P.PY_SETUP_PY.items():
@@ -261,7 +270,8 @@ def task_build():
 
         file_dep = [
             *P.PY_SETUP_DEPS[py_name](),
-            *py_pkg.rglob("*.py"),
+            *py_pkg.rglob("src/*.py"),
+            *py_pkg.glob("*.md"),
             setup_py,
         ]
 
@@ -603,6 +613,7 @@ class P:
 
     # docs
     README = ROOT / "README.md"
+    PY_README = ROOT / f"py/{C.NAME}/README.md"
     CONTRIBUTING = ROOT / "CONTRIBUTING.md"
     CHANGELOG = ROOT / "CHANGELOG.md"
     DOCS = ROOT / "docs"

--- a/dodo.py
+++ b/dodo.py
@@ -308,6 +308,17 @@ def task_dist():
     )
 
 
+@doit.create_after("dist")
+def task_distcheck():
+    for dist in [*B.DIST.glob("*.whl"), *B.DIST.glob("*.tar.gz")]:
+        yield dict(
+            name=f"twine:{dist.name}",
+            doc=f"use twine to validate {dist.name}",
+            file_dep=[dist],
+            actions=[["twine", "check", dist]],
+        )
+
+
 def task_dev():
     """setup up local packages for interactive development"""
     if C.TESTING_IN_CI or C.DOCS_IN_CI or C.LINTING_IN_CI:

--- a/dodo.py
+++ b/dodo.py
@@ -307,7 +307,10 @@ def task_dist():
         targets=[B.DIST / "SHA256SUMS"],
     )
 
-    for dist in [*B.DIST.glob("*.whl"), *B.DIST.glob("*.tar.gz")]:
+    for dist in B.DISTRIBUTIONS:
+        if dist.name.endswith(".tar.gz"):
+            # apparently flit sdists are malformed according to `twine check`
+            continue
         yield dict(
             name=f"twine:{dist.name}",
             doc=f"use twine to validate {dist.name}",

--- a/py/jupyterlite/README.md
+++ b/py/jupyterlite/README.md
@@ -37,20 +37,22 @@ archive.
 python3 -m pip install --pre jupyterlite
 ```
 
-Use the [`jupyter lite` CLI][cli] to `build`, `check`, or create a reproducible,
-remixable `archive` of your site, then [deploy] your built site to any static host, such
-as GitHub Pages or ReadTheDocs.
+Use the [`jupyter lite` CLI][cli] to `build`, `check`, or create a [reproducible],
+remixable `archive` of your site, then [publish] your built site to any static host,
+such as GitHub Pages or ReadTheDocs.
 
 | `jupyter lite` | description                                         | extras                                |
 | -------------: | --------------------------------------------------- | ------------------------------------- |
 |         `init` | build an empty site from the bundled app archive    |                                       |
 |        `build` | add your own notebooks, labextensions, and settings | `jupyter_server` for indexing content |
-|        `serve` | try out your site locally                           |                                       |
+|        `serve` | try out your site locally                           | `tornado` for snappier serving        |
 |        `check` | check your site's metadata                          | `jsonschema` for schema validation    |
 |      `archive` | create a single-file archive                        |                                       |
 
 [cli]: https://jupyterlite.readthedocs.io/en/latest/cli.html
-[deploy]: https://jupyterlite.readthedocs.io/en/latest/deploying.html
+[publish]: https://jupyterlite.readthedocs.io/en/latest/deploying.html
+[reproducible]:
+  https://jupyterlite.readthedocs.io/en/latest/cli.html#reproducible-archives
 
 ## Features
 
@@ -59,22 +61,27 @@ as GitHub Pages or ReadTheDocs.
 ### Browser-based Interactive Computing
 
 - Python kernel backed by [Pyodide](https://pyodide.org) running in a Web Worker
-- JavaScript kernel running in an `IFrame`
-- Combine Offline Notebook storage in browser `localStorage` or `IndexDB` with example
-  files
+  - Initial support for interactive visualization libraries such as `altair`, `bqplot`,
+    `ipywidgets`, `matplotlib`, and `plotly`
+- JavaScript and [P5.js] kernels running in an `IFrame`
+- View hosted example Notebooks and other files, then edit, save, and download from the
+  browser's `IndexDB` (or `localStorage`)
 - Support for saving settings for JupyterLab/Lite core and federated extensions
 - Basic session and kernel management to have multiple kernels running at the same time
 - Support for
   [Code Consoles](https://jupyterlab.readthedocs.io/en/stable/user/code_console.html)
-- Initial support for interactive visualization libraries such as `altair`, `bqplot`,
-  `ipywidgets`, `matplotlib`, and `plotly`
+
+[p5.js]: https://p5js.org/
 
 ### Ease of Deployment
 
-- Served via well-cacheable, static HTTP(S), works on most static web hosts, and locally
+- Served via well-cacheable, static HTTP(S), locally or on most static web hosts
 - Embeddable within larger applications
 - Requires no dedicated _application server_ much less a container orchestrator
-- Fine-grained configurability of page settings, including reuse of federated extensions
+- Fine-grained [configurability] of page settings, including reuse of federated
+  extensions
+
+[configurability]: https://jupyterlite.readthedocs.io/en/latest/configuring.html
 
 ## Status
 
@@ -109,7 +116,3 @@ See also:
   literal notebooks
 - [Basthon](https://basthon.fr/about.html): A Jupyter notebook implementation using
   Pyodide
-
-```
-
-```

--- a/py/jupyterlite/README.md
+++ b/py/jupyterlite/README.md
@@ -34,7 +34,7 @@ Install `jupyterlite` from PyPI, which comes with the CLI and a pre-built, empty
 archive.
 
 ```bash
-python3 -m pip install --pre jupyterlite
+python -m pip install --pre jupyterlite
 ```
 
 Use the [`jupyter lite` CLI][cli] to `build`, `check`, or create a [reproducible],

--- a/py/jupyterlite/README.md
+++ b/py/jupyterlite/README.md
@@ -34,7 +34,7 @@ Install `jupyterlite` from PyPI, which comes with the CLI and a pre-built, empty
 archive.
 
 ```bash
-pip install --pre jupyterlite
+python3 -m pip install --pre jupyterlite
 ```
 
 Use the [`jupyter lite` CLI][cli] to `build`, `check`, or create a reproducible,

--- a/py/jupyterlite/README.md
+++ b/py/jupyterlite/README.md
@@ -1,58 +1,115 @@
-# jupyterlite
+# JupyterLite
 
-A build tool for creating ready-to-ship [JupyterLite][docs] sites.
+[![ci-badge]][ci] [![binder-badge]][binder] [![docs-badge]][docs]
 
-It contains:
+[ci-badge]: https://github.com/jtpio/jupyterlite/workflows/Build/badge.svg
+[ci]: https://github.com/jtpio/jupyterlite/actions?query=branch%3Amain
+[binder-badge]: https://mybinder.org/badge_logo.svg
+[binder]: https://mybinder.org/v2/gh/jtpio/jupyterlite/main?urlpath=lab
+[docs-badge]: https://readthedocs.org/projects/jupyterlite/badge/?version=latest
+[docs]: https://jupyterlite.readthedocs.io/en/latest/?badge=latest
 
-- the static assets for a baseline `jupyterlite` site
-- the [command line](#command-line) tool, `jupyter lite`
-- optional [integrations](#integrations) for nbconvert, sphinx
+JupyterLite is a JupyterLab distribution that **runs entirely in the browser** built
+from the ground-up using JupyterLab components and extensions.
 
-## Installation
+## ✨ Try it in your browser ✨
+
+JupyterLite works with both [JupyterLab](https://github.com/jupyterlab/jupyterlab) and
+[RetroLab](https://github.com/jupyterlab/retrolab).
+
+| [Try it with JupyterLab!] | [Try it with RetroLab!] |
+| :-----------------------: | :---------------------: |
+|     ![lab-screenshot]     |   ![retro-screenshot]   |
+
+[try it with jupyterlab!]: https://jupyterlite.readthedocs.io/en/latest/try/lab
+[lab-screenshot]:
+  https://user-images.githubusercontent.com/591645/114009512-7fe79600-9863-11eb-9aac-3a9ef6345011.png
+[try it with retrolab!]: https://jupyterlite.readthedocs.io/en/latest/try/retro
+[retro-screenshot]:
+  https://user-images.githubusercontent.com/591645/114454062-78fdb200-9bda-11eb-9cda-4ee327dd1c77.png
+
+## 🏗️ Build your own JupyterLite 🏗️
+
+Install `jupyterlite` from PyPI, which comes with the CLI and a pre-built, empty site
+archive.
 
 ```bash
-# TBD pip install jupyterlite
-# or...
-# TBD mamba install -c conda-forge jupyterlite
-# or...
-# TBD conda install -c conda-forge jupyterlite
+pip install --pre jupyterlite
 ```
 
-## Command Line
+Use the [`jupyter lite` CLI][cli] to `build`, `check`, or create a reproducible,
+remixable `archive` of your site, then [deploy] your built site to any static host, such
+as GitHub Pages or ReadTheDocs.
 
-#### `jupyter lite init [--notebook]`
+| `jupyter lite` | description                                         | extras                                |
+| -------------: | --------------------------------------------------- | ------------------------------------- |
+|         `init` | build an empty site from the bundled app archive    |                                       |
+|        `build` | add your own notebooks, labextensions, and settings | `jupyter_server` for indexing content |
+|        `serve` | try out your site locally                           |                                       |
+|        `check` | check your site's metadata                          | `jsonschema` for schema validation    |
+|      `archive` | create a single-file archive                        |                                       |
 
-Creates a `jupyter-lite-build.json` (default) or `.ipynb` in the current working
-directory with defaults, and prints the contents.
+[cli]: https://jupyterlite.readthedocs.io/en/latest/cli.html
+[deploy]: https://jupyterlite.readthedocs.io/en/latest/deploying.html
 
-This file allows for extensible, fine-grained control over the built site.
+## Features
 
-#### `jupyter lite build [PATH]`
+> For more details, see the [JupyterLite documentation](https://jupyterlite.rtfd.io).
 
-Updates a JupyterLite site in the current working directory (default) or given `PATH`
-with the default settings.
+### Browser-based Interactive Computing
 
-If a `jupyter-lite-build.json` or `jupyter-lite-build.ipynb` is found, the values there
-will be merged with the defaults.
+- Python kernel backed by [Pyodide](https://pyodide.org) running in a Web Worker
+- JavaScript kernel running in an `IFrame`
+- Combine Offline Notebook storage in browser `localStorage` or `IndexDB` with example
+  files
+- Support for saving settings for JupyterLab/Lite core and federated extensions
+- Basic session and kernel management to have multiple kernels running at the same time
+- Support for
+  [Code Consoles](https://jupyterlab.readthedocs.io/en/stable/user/code_console.html)
+- Initial support for interactive visualization libraries such as `altair`, `bqplot`,
+  `ipywidgets`, `matplotlib`, and `plotly`
 
-##### `build` options
+### Ease of Deployment
 
-| Option        | Description                                                 | Notes                                      |
-| ------------- | ----------------------------------------------------------- | ------------------------------------------ |
-| `--serve`     | After building the site, serve it over http on `localhost`. | This is **not** a production-grade server! |
-| `--port=PORT` | The port on which to serve                                  |                                            |
-| `--https`     | Serve with a self-signed SSL certificate                    | Requires `trustme`.                        |
+- Served via well-cacheable, static HTTP(S), works on most static web hosts, and locally
+- Embeddable within larger applications
+- Requires no dedicated _application server_ much less a container orchestrator
+- Fine-grained configurability of page settings, including reuse of federated extensions
 
-#### `jupyter lite watch [PATH]`
+## Status
 
-Watch the `PATH` for changes rebuild accordingly. Accepts all
-[build options](#build-options).
+⚠️ Currently in active development ⚠️
 
-## Integrations
+## Development install
 
-### `jupyter nbconvert --to jupyterlite`
+See the
+[contributing guide](https://github.com/jtpio/jupyterlite/blob/main/CONTRIBUTING.md) for
+a development installation.
 
-Uses the `jupyterlite.nbconvert.LiteExporter` to export a notebook that contains
-`jupyterlite` metadata as a full site.
+## Related
 
-[docs]: https://jupyterlite.rtfd.io
+JupyterLite is a reboot of several attempts at making a full static Jupyter distribution
+that runs in the browser, without having to start the Python Jupyter Server on the host
+machine.
+
+The goal is to provide a lightweight computing environment accessible in a matter of
+seconds with a single click, in a web browser and without having to install anything.
+
+This project is a collection of packages that can be remixed together in variety of ways
+to create new applications and distributions. Most of the packages in this repo focus on
+providing server-like components that run in the browser (to manage kernels, files and
+settings), so existing JupyterLab extensions and plugins can be reused out of the box.
+
+See also:
+
+- [p5-notebook](https://github.com/jtpio/p5-notebook): A minimal Jupyter Notebook UI for
+  p5.js kernels running in the browser
+- [jyve](https://github.com/deathbeds/jyve): Jupyter Kernels, right inside JupyterLab
+- [Starboard Notebook](https://github.com/gzuidhof/starboard-notebook): In-browser
+  literal notebooks
+- [Basthon](https://basthon.fr/about.html): A Jupyter notebook implementation using
+  Pyodide
+
+```
+
+```

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -5,6 +5,8 @@ requires = ["flit_core >=3.1,<4"]
 [tool.flit.metadata]
 module = "jupyterlite"
 author = "JupyterLite Contributors"
+description-file = "README.md"
+license = "BSD-3-Clause"
 home-page = "https://github.com/jtpio/jupyterlite"
 requires-python = ">=3.7"
 requires = [
@@ -13,6 +15,21 @@ requires = [
     "jupyter_core >=4.7",
     # TODO: support wheels https://github.com/jtpio/jupyterlite/issues/151
     # "wheel",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Framework :: Jupyter",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python",
+    "Topic :: Software Development :: Documentation",
+    "Topic :: Software Development :: Pre-processors",
+    "Topic :: Text Processing :: Markup :: HTML",
 ]
 
 [tool.flit.scripts]
@@ -38,6 +55,9 @@ contents = [
 ]
 serve = [
     "tornado >=6.1",
+]
+check = [
+    "jsonschema >=3"
 ]
 
 [tool.flit.entrypoints."jupyterlite.addon.v0"]

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -16,6 +16,7 @@ requires = [
     # TODO: support wheels https://github.com/jtpio/jupyterlite/issues/151
     # "wheel",
 ]
+keywords = "jupyterlab,jupyter,notebook,schema,pyodide,browser,js,p5.js,doit"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Framework :: Jupyter",

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,3 +2,4 @@
 # see .binder/ and docs/ for full development/docs environments
 doit >=0.33,<0.34
 flit >=3.1
+twine

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -6,3 +6,4 @@ black
 isort
 jsonschema >=3
 pyflakes
+twine

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -6,4 +6,3 @@ black
 isort
 jsonschema >=3
 pyflakes
-twine


### PR DESCRIPTION
## References

- fixes #183

## Code changes

- [x] adds `dist:twine` doit tasks which runs `twine check` on each ~~dist~~ wheel
  - > `flit` sdists don't pass `twine check` :crying_cat_face: 
- [x] patch up the metadata
  - [x] `description-file`
  - [x] `classifiers`
  - [x] `license`
  - [x] `keywords` 
- [x] make `jsonschema` an optional dependency
  - [x] throw some `warnings` but don't fail 
- [x] copies the root README to `py/jupyterlite` before building
  - [x] adds a short table about installing, using the CLI
- [x] smoke tests the CLI on each platform _before_ installing test dependencies
  - > `linux` and `osx` build the same `sha256sum`, a la :tada: https://github.com/jtpio/jupyterlite/pull/172#issuecomment-867625254 

## User-facing changes

- users should see something on PyPI :blush:

## Backwards-incompatible changes

- n/a