### PR TITLE
Add link to the demo GitHub Pages repo

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -229,7 +229,15 @@ automatically get a preview link when opening a new pull request:
 
 ### GitHub Pages
 
-> TBD
+JupyterLite can easily be deployed on GitHub Pages, using the `jupyterlite` CLI to add
+content and extensions.
+
+```{hint}
+See the [github pages demo] for an example. That repository is a GitHub template repository
+which makes it convenient to generate a new JupyterLite site with a single click.
+```
+
+[github pages demo]: https://github.com/jtpio/jupyterlite-demo
 
 ### GitLab Pages
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jtpio/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes #114 

For now it's just linking to https://github.com/jtpio/jupyterlite-demo since the repo in self-contained.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

None, docs change.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

More visible instructions to deploy a JupyterLite on GitHub Pages.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
