### PR TITLE
move more path logic to traitlets

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -26,9 +26,9 @@ dependencies:
   # build
   - doit >=0.33,<0.34
   - flit >=3.1
-  - jsonschema >=3
   - pip
   - wheel
+  - jsonschema >=3
   - yarn <2
   # cli
   - wheel

--- a/py/jupyterlite/src/jupyterlite/app.py
+++ b/py/jupyterlite/src/jupyterlite/app.py
@@ -47,11 +47,11 @@ class ManagedApp(BaseLiteApp):
             parent=self,
         )
         if self.lite_dir:
-            kwargs["lite_dir"] = Path(self.lite_dir).resolve()
+            kwargs["lite_dir"] = self.lite_dir
         if self.app_archive:
-            kwargs["app_archive"] = Path(self.app_archive)
+            kwargs["app_archive"] = self.app_archive
         if self.output_dir:
-            kwargs["output_dir"] = Path(self.output_dir).resolve()
+            kwargs["output_dir"] = self.output_dir
         if self.files:
             kwargs["files"] = [Path(p) for p in self.files]
         if self.ignore_files:

--- a/py/jupyterlite/src/jupyterlite/config.py
+++ b/py/jupyterlite/src/jupyterlite/config.py
@@ -7,12 +7,15 @@
 """
 import os
 from pathlib import Path
+from typing import Optional as _Optional
+from typing import Text as _Text
+from typing import Tuple as _Tuple
 
-from traitlets import CInt, Tuple, default
+from traitlets import CInt, Tuple, Unicode, default
 from traitlets.config import LoggingConfigurable
 
 from . import constants as C
-from .trait_types import CPath
+from .trait_types import CPath, TypedTuple
 
 
 class LiteBuildConfig(LoggingConfigurable):
@@ -29,19 +32,19 @@ class LiteBuildConfig(LoggingConfigurable):
     loader paths
     """
 
-    disable_addons = Tuple(
-        allow_none=True,
+    disable_addons: _Tuple[_Text] = TypedTuple(
+        Unicode(),
         help=("skip loading `entry_point` for these addons. TODO: should be a dict"),
     ).tag(config=True)
 
-    apps = Tuple(
+    apps: _Tuple[_Text] = TypedTuple(
+        Unicode(),
         help=(
             f"""the Lite apps: currently {C.JUPYTERLITE_APPS}. """
             f"""Required: {C.JUPYTERLITE_APPS_REQUIRED}"""
         ),
     ).tag(config=True)
 
-    # a bunch of paths
     app_archive: Path = CPath(
         help=(f"""The app archive to use, default: {C.DEFAULT_APP_ARCHIVE}""")
     ).tag(config=True)
@@ -56,19 +59,20 @@ class LiteBuildConfig(LoggingConfigurable):
 
     output_archive: Path = CPath(help="Archive to create").tag(config=True)
 
-    # actually some more paths
-    files = Tuple(allow_none=True).tag(config=True)
-
-    overrides = Tuple(allow_none=True, help=("Specific overrides.json to include")).tag(
-        config=True
-    )
-
-    # patterns
-    ignore_files = Tuple(
-        allow_none=True, help="Path patterns that should never be included"
+    files: _Tuple[Path] = TypedTuple(
+        CPath(), help="Files to add and index as Jupyter Contents"
     ).tag(config=True)
 
-    source_date_epoch = CInt(
+    overrides: _Tuple[_Text] = TypedTuple(
+        CPath(), help=("Specific overrides.json to include")
+    ).tag(config=True)
+
+    # patterns
+    ignore_files: _Tuple[_Text] = Tuple(
+        help="Path patterns that should never be included"
+    ).tag(config=True)
+
+    source_date_epoch: _Optional[int] = CInt(
         allow_none=True,
         min=1,
         help="Trigger reproducible builds, clamping timestamps to this value",

--- a/py/jupyterlite/src/jupyterlite/trait_types.py
+++ b/py/jupyterlite/src/jupyterlite/trait_types.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from traitlets import TraitType
+from traitlets import Container, TraitType
 
 
 class CPath(TraitType):
@@ -8,9 +8,19 @@ class CPath(TraitType):
 
     def validate(self, obj, value) -> Path:
         if isinstance(value, Path):
-            return value
+            return value.resolve()
 
         try:
-            return Path(str(value))
+            return Path(str(value)).resolve()
         except Exception:
             self.error(obj, value)
+
+
+class TypedTuple(Container):
+    """A trait for a tuple of any length with type-checked elements.
+
+    From: https://github.com/jupyter-widgets/ipywidgets/blob/7.6.3/ipywidgets/widgets/trait_types.py#L213
+    """
+
+    klass = tuple
+    _cast_types = (list,)


### PR DESCRIPTION
## References

- further refines solution to #185, as provided by #200 

## Code changes

- [x] cargo cult `TypedTuple` from `ipywidgets.trait_types`
- [x] makes all path-based config traits `CPath` or `Tuple(CPath())`
- [x] does more `.resolve`ing 

## User-facing changes

- n/a

## Backwards-incompatible changes

- n/a