### PR TITLE
Hoist port and base_url to CLI

### DIFF
--- a/docs/cli.ipynb
+++ b/docs/cli.ipynb
@@ -296,6 +296,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "212aa2c4-6a73-494c-a872-9d75693f87e8",
+   "metadata": {},
+   "source": [
+    "### Serve\n",
+    "\n",
+    "Serve the `--output-dir` on `http://127.0.0.1:{--port=8000}{--base-url=/}`.\n",
+    "\n",
+    "```{warning}\n",
+    "This is _not_ a production server. Please consider _any_ of the [deployment](./deploying.md) options\n",
+    "before trying to make this something it isn't.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afb00066-9d95-4e2d-9f43-0a350586e49d",
+   "metadata": {
+    "tags": [
+     "output_scroll",
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "!jupyter lite serve --help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6b437ed9-4a8b-42cf-a8da-a1282daed39c",
    "metadata": {},
    "source": [
@@ -508,7 +538,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/cli.ipynb
+++ b/docs/cli.ipynb
@@ -154,16 +154,17 @@
    "metadata": {},
    "source": [
     "### Common Parameters\n",
-    "\n",
-    "- `--lite-dir` (default: working directory) configuration and content for the site\n",
-    "- `--output-dir` (default: `_output`) where the hostable site will be created\n",
-    "- `--app-archive` (default: bundled) an alternate site to base off of\n",
-    "- `--files` (default: `files`) directory to copy to `_output/files/` and available as\n",
-    "  _Contents_\n",
-    "- `--ignore-files` (default: [`untitled*`, `.ipynb_checkpoints`, `.git`]) patterns that\n",
-    "  should _never_ be included in `/files/` (even if found in `lite-dir`).\n",
-    "- `--output-archive` (default: `<directory->-jupyterlite.tgz`) the name of the tarball\n",
-    "- `--source-date-epoch` optionally enable additional reproducible build measures (best-effort!)"
+    "| parameter             | description                                                                          | default                       | environment variable        |\n",
+    "| --------------------- | ------------------------------------------------------------------------------------ | ----------------------------- | --------------------------- |\n",
+    "| `--lite-dir`          | configuration and content for the site                                               | current working directory     | `JUPYTERLITE_DIR`           |\n",
+    "| `--output-dir`        | where the hostable site will be created                                              | `_output`                     | `JUPYTERLITE_OUTPUT_DIR`    |\n",
+    "| `--app-archive`       | an alternate site to base off of                                                     | bundled                       |                             |\n",
+    "| `--files`             | directory to copy to `_output/files/` and available as _Contents_                    | `./files`                     |                             |\n",
+    "| `--ignore-files`      | patterns that should _never_ be included in `/files/` (even if found in `lite-dir`). | various                       |                             |\n",
+    "| `--output-archive`    | the path to the archive                                                              | `<directory>-jupyterlite.tgz` | `JUPYTERLAB_OUTPUT_ARCHIVE` |\n",
+    "| `--port`              | port on `127.0.0.1` to serve the test server                                         | `8000`                        | `JUPYTERLITE_PORT`          |\n",
+    "| `--base-url`          | the URL prefix to include before the site                                            | `/`                           | `JUPYTERLITE_BASE_URL`      |\n",
+    "| `--source-date-epoch` | optionally enable additional reproducible build measures (best-effort!)              |                               | `SOURCE_DATE_EPOCH`         |\n"
    ]
   },
   {

--- a/py/jupyterlite/src/jupyterlite/addons/serve.py
+++ b/py/jupyterlite/src/jupyterlite/addons/serve.py
@@ -2,16 +2,18 @@
 import sys
 
 import doit
-from traitlets import Bool, Int, default
+from traitlets import Bool, default
 
 from .base import BaseAddon
+
+# we _really_ don't want to be in the server-running business, so hardcode, now...
+HOST = "127.0.0.1"
 
 
 class ServeAddon(BaseAddon):
     __all__ = ["status", "serve"]
 
     has_tornado: bool = Bool()
-    port: int = Int(8000)
 
     @default("has_tornado")
     def _default_has_tornado(self):
@@ -27,33 +29,45 @@ class ServeAddon(BaseAddon):
             name="contents",
             actions=[
                 lambda: print(
-                    f"""    will serve {self.port} with: {"tornado" if self.has_tornado else "stdlib"}"""
+                    f"""    will serve {manager.port} with: {"tornado" if self.has_tornado else "stdlib"}"""
                 )
             ],
         )
 
-    def serve(self, manager):
-        task = dict(
-            name="serve",
-            doc=f"run server at http://localhost:{self.port}/ for {manager.output_dir}",
-            uptodate=[lambda: False],
-        )
+    @property
+    def url(self):
+        return f"http://{HOST}:{self.manager.port}{self.manager.base_url}"
 
+    def serve(self, manager):
         if self.has_tornado:
-            task["actions"] = [(self._serve_tornado, [])]
+            name = "tornado"
+            actions = [(self._serve_tornado, [])]
         else:
-            task["actions"] = [
+            name = "stdlib"
+            actions = [
                 lambda: self.log.info(
                     "Using python's built-in http.server: "
-                    "install tornado for a snappier experience"
+                    "install tornado for a snappier experience and base_url"
                 ),
                 doit.tools.Interactive(
-                    [sys.executable, "-m", "http.server", "-b", "localhost"],
+                    [
+                        sys.executable,
+                        "-m",
+                        "http.server",
+                        "-b",
+                        HOST,
+                        f"{self.manager.port}",
+                    ],
                     cwd=str(self.manager.output_dir),
                     shell=False,
                 ),
             ]
-        yield task
+        yield dict(
+            name=name,
+            doc=f"run server at {self.url} for {manager.output_dir}",
+            uptodate=[lambda: False],
+            actions=actions,
+        )
 
     def _serve_tornado(self):
         from tornado import ioloop, web
@@ -65,7 +79,7 @@ class ServeAddon(BaseAddon):
                 return url_path
 
         path = str(self.manager.output_dir)
-        routes = [("/(.*)", Handler, {"path": path})]
+        routes = [(self.manager.base_url + "(.*)", Handler, {"path": path})]
         app = web.Application(routes, debug=True)
         self.log.warning(
             f"""
@@ -73,13 +87,13 @@ class ServeAddon(BaseAddon):
         Serving JupyterLite from:
             {path}
         on:
-            http://localhost:{self.port}/
+            {self.url}
 
         *** Press Ctrl+C to exit **
         """
         )
-        app.listen(self.port)
+        app.listen(self.manager.port)
         try:
             ioloop.IOLoop.instance().start()
         except KeyboardInterrupt:
-            self.log.warning(f"""Stopping http://localhost:{self.port}...""")
+            self.log.warning(f"Stopping {self.url}")

--- a/py/jupyterlite/src/jupyterlite/app.py
+++ b/py/jupyterlite/src/jupyterlite/app.py
@@ -28,6 +28,9 @@ class BaseLiteApp(JupyterApp, LiteBuildConfig):
             "output-archive": "LiteBuildConfig.output_archive",
             "overrides": "LiteBuildConfig.overrides",
             "source-date-epoch": "LiteBuildConfig.source_date_epoch",
+            # addon-specific things
+            "port": "LiteBuildConfig.port",
+            "base-url": "LiteBuildConfig.base_url",
         },
     )
 
@@ -66,6 +69,10 @@ class ManagedApp(BaseLiteApp):
             kwargs["disable_addons"] = self.disable_addons
         if self.source_date_epoch is not None:
             kwargs["source_date_epoch"] = self.source_date_epoch
+        if self.port is not None:
+            kwargs["port"] = self.port
+        if self.base_url is not None:
+            kwargs["base_url"] = self.base_url
 
         return LiteManager(**kwargs)
 

--- a/py/jupyterlite/src/jupyterlite/config.py
+++ b/py/jupyterlite/src/jupyterlite/config.py
@@ -69,9 +69,9 @@ class LiteBuildConfig(LoggingConfigurable):
 
     # serving
     port: int = CInt(
-        8000, help="[serve] the port to (insecurely) expose on http://127.0.0.1"
+        help="[serve] the port to (insecurely) expose on http://127.0.0.1"
     ).tag(config=True)
-    base_url: int = Unicode("/", help="[serve] the prefix to use").tag(config=True)
+    base_url: int = Unicode(help="[serve] the prefix to use").tag(config=True)
 
     # patterns
     ignore_files: _Tuple[_Text] = Tuple(
@@ -161,3 +161,11 @@ class LiteBuildConfig(LoggingConfigurable):
             return None
         sde = int(os.environ[C.SOURCE_DATE_EPOCH])
         return sde
+
+    @default("port")
+    def _default_port(self):
+        return int(os.environ.get("JUPYTERLITE_PORT", 8000))
+
+    @default("base_url")
+    def _default_base_url(self):
+        return os.environ.get("JUPYTERLITE_BASE_URL", "/")

--- a/py/jupyterlite/src/jupyterlite/config.py
+++ b/py/jupyterlite/src/jupyterlite/config.py
@@ -67,6 +67,12 @@ class LiteBuildConfig(LoggingConfigurable):
         CPath(), help=("Specific overrides.json to include")
     ).tag(config=True)
 
+    # serving
+    port: int = CInt(
+        8000, help="[serve] the port to (insecurely) expose on http://127.0.0.1"
+    ).tag(config=True)
+    base_url: int = Unicode("/", help="[serve] the prefix to use").tag(config=True)
+
     # patterns
     ignore_files: _Tuple[_Text] = Tuple(
         help="Path patterns that should never be included"

--- a/py/jupyterlite/src/jupyterlite/config.py
+++ b/py/jupyterlite/src/jupyterlite/config.py
@@ -46,18 +46,20 @@ class LiteBuildConfig(LoggingConfigurable):
     ).tag(config=True)
 
     app_archive: Path = CPath(
-        help=(f"""The app archive to use, default: {C.DEFAULT_APP_ARCHIVE}""")
+        help=("The app archive to use. env: JUPYTERLITE_APP_ARCHIVE")
     ).tag(config=True)
 
-    lite_dir: Path = CPath(help=("""The root folder of a JupyterLite project""")).tag(
-        config=True
-    )
+    lite_dir: Path = CPath(
+        help=("The root folder of a JupyterLite project. env: JUPYTERLITE_DIR")
+    ).tag(config=True)
 
-    output_dir: Path = CPath(help=("""Where to build the JupyterLite site""")).tag(
-        config=True
-    )
+    output_dir: Path = CPath(
+        help=("Where to build the JupyterLite site. env: JUPYTERLITE_OUTPUT_DIR")
+    ).tag(config=True)
 
-    output_archive: Path = CPath(help="Archive to create").tag(config=True)
+    output_archive: Path = CPath(
+        help=("Archive to create." " env: JUPYTERLITE_OUTPUT_ARCHIVE")
+    ).tag(config=True)
 
     files: _Tuple[Path] = TypedTuple(
         CPath(), help="Files to add and index as Jupyter Contents"
@@ -69,9 +71,14 @@ class LiteBuildConfig(LoggingConfigurable):
 
     # serving
     port: int = CInt(
-        help="[serve] the port to (insecurely) expose on http://127.0.0.1"
+        help=(
+            "[serve] the port to (insecurely) expose on http://127.0.0.1."
+            " env: JUPYTERLITE_PORT"
+        )
     ).tag(config=True)
-    base_url: int = Unicode(help="[serve] the prefix to use").tag(config=True)
+    base_url: str = Unicode(
+        help=("[serve] the prefix to use." " env: JUPYTERLITE_BASE_URL")
+    ).tag(config=True)
 
     # patterns
     ignore_files: _Tuple[_Text] = Tuple(
@@ -102,7 +109,7 @@ class LiteBuildConfig(LoggingConfigurable):
 
     @default("lite_dir")
     def _default_lite_dir(self):
-        return Path.cwd()
+        return Path(os.environ.get("JUPYTERLITE_DIR", Path.cwd()))
 
     @default("files")
     def _default_files(self):

--- a/py/jupyterlite/src/jupyterlite/config.py
+++ b/py/jupyterlite/src/jupyterlite/config.py
@@ -58,7 +58,7 @@ class LiteBuildConfig(LoggingConfigurable):
     ).tag(config=True)
 
     output_archive: Path = CPath(
-        help=("Archive to create." " env: JUPYTERLITE_OUTPUT_ARCHIVE")
+        help=("Archive to create. env: JUPYTERLITE_OUTPUT_ARCHIVE")
     ).tag(config=True)
 
     files: _Tuple[Path] = TypedTuple(
@@ -133,7 +133,8 @@ class LiteBuildConfig(LoggingConfigurable):
     @default("ignore_files")
     def _default_ignore_files(self):
         return [
-            ".*\.pyc" "/\.git/",
+            ".*\.pyc",
+            "/\.git/",
             "/\.gitignore",
             "/\.ipynb_checkpoints/",
             "/build/",

--- a/py/jupyterlite/src/jupyterlite/tests/conftest.py
+++ b/py/jupyterlite/src/jupyterlite/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import shutil
 import time
+import warnings
 
 import pytest
 
@@ -13,7 +14,10 @@ def an_empty_lite_dir(tmp_path):
     lite_dir = tmp_path / "a_lite_dir"
     lite_dir.mkdir()
     yield lite_dir
-    shutil.rmtree(lite_dir)
+    try:
+        shutil.rmtree(lite_dir)
+    except Exception as err:
+        warnings.warn(f"failed to clean up {lite_dir}: {err}")
 
 
 @pytest.fixture

--- a/py/jupyterlite/src/jupyterlite/tests/test_serve.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_serve.py
@@ -1,0 +1,65 @@
+"""Test that various serving options work"""
+
+import subprocess
+import time
+
+import pytest
+from tornado import httpclient
+
+
+@pytest.mark.parametrize("base_url,port", [[None, None], ["/@foo/", 8001]])
+def test_serve(an_empty_lite_dir, script_runner, base_url, port):
+    """verify that serving kinda works"""
+    args = ["jupyter", "lite", "serve"]
+
+    if port:
+        args += ["--port", f"{port}"]
+    else:
+        port = 8000
+
+    if base_url:
+        args += ["--base-url", base_url]
+    else:
+        base_url = "/"
+
+    url = f"http://127.0.0.1:{port}{base_url}"
+
+    server = subprocess.Popen(args, cwd=an_empty_lite_dir)
+
+    app_urls = [
+        "",
+        "lab/",
+        "lab/index.html",
+        "retro/",
+        "retro/index.html",
+        "retro/tree/",
+        "retro/tree/index.html",
+    ]
+
+    maybe_errors = [_fetch_without_errors(f"{url}{frag}") for frag in app_urls]
+
+    errors = [e for e in maybe_errors if e is not None]
+
+    try:
+        assert not errors
+    finally:
+        server.terminate()
+
+
+def _fetch_without_errors(url, retries=10):
+    retries = 10
+    last_error = None
+
+    while retries:
+        retries -= 1
+        last_error = None
+        try:
+            client = httpclient.HTTPClient()
+            r = client.fetch(url)
+            assert b"jupyter-config-data" in r.body
+            break
+        except Exception as err:
+            print(f"{err}: {retries} retries left...")
+            time.sleep(0.5)
+            last_error = err
+    return last_error

--- a/py/jupyterlite/src/jupyterlite/tests/test_serve.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_serve.py
@@ -25,16 +25,16 @@ def test_serve(an_empty_lite_dir, script_runner, base_url, port):
     url = f"http://127.0.0.1:{port}{base_url}"
 
     server = subprocess.Popen(args, cwd=an_empty_lite_dir)
+    time.sleep(2)
 
-    app_urls = [
-        "",
-        "lab/",
-        "lab/index.html",
-        "retro/",
-        "retro/index.html",
-        "retro/tree/",
-        "retro/tree/index.html",
-    ]
+    app_urls = [""]
+    for app in ["lab", "retro"]:
+        app_urls += [
+            f"{app}/",
+            f"{app}/index.html",
+        ]
+        if app == "retro":
+            app_urls += [f"{app}/tree/", f"{app}/tree/index.html"]
 
     maybe_errors = [_fetch_without_errors(f"{url}{frag}") for frag in app_urls]
 
@@ -44,6 +44,7 @@ def test_serve(an_empty_lite_dir, script_runner, base_url, port):
         assert not errors
     finally:
         server.terminate()
+        server.wait(timeout=10)
 
 
 def _fetch_without_errors(url, retries=10):


### PR DESCRIPTION
## References

- fixes #208

## Code changes

- [x] adds `--port=8000` and `--base-url=/` CLI options
  - [x] can also be set by `JUPYTERLITE_(PORT|BASE_URL)`
  - [x] some docs 

## User-facing changes

- `jupyter lite serve` will now host on different ports and url prefixes
- docs include environment variables

![Screenshot from 2021-07-05 14-24-29](https://user-images.githubusercontent.com/45380/124507882-c3876880-dd9c-11eb-89e5-ddf4e3b42570.png)


## Backwards-incompatible changes

- n/a: defaults are maintained