### PR TITLE
hoist defaultKernelName

### DIFF
--- a/app/jupyterlite.schema.v0.json
+++ b/app/jupyterlite.schema.v0.json
@@ -55,7 +55,7 @@
           "$ref": "#/definitions/non-trailing-slash-uri"
         },
         "defaultKernelName": {
-          "description": "The name of the default kernel",
+          "description": "The name of the default kernel. If not available, the first kernel (by alphabetic ordering) will be chosen.",
           "default": "python",
           "type": "string"
         },

--- a/packages/kernel/src/kernelspecs.ts
+++ b/packages/kernel/src/kernelspecs.ts
@@ -29,8 +29,11 @@ export class KernelSpecs implements IKernelSpecs {
     let defaultKernelName = PageConfig.getOption('defaultKernelName');
 
     if (!defaultKernelName && this._specs.size) {
-      defaultKernelName = this._specs.keys().next().value;
+      const keys = Array.from(this._specs.keys());
+      keys.sort();
+      defaultKernelName = keys[0];
     }
+
     return defaultKernelName || FALLBACK_KERNEL;
   }
 

--- a/packages/kernel/src/kernelspecs.ts
+++ b/packages/kernel/src/kernelspecs.ts
@@ -2,7 +2,7 @@ import { PageConfig } from '@jupyterlab/coreutils';
 
 import { KernelSpec } from '@jupyterlab/services';
 
-import { IKernel, IKernelSpecs } from './tokens';
+import { IKernel, IKernelSpecs, FALLBACK_KERNEL } from './tokens';
 
 /**
  * A class to handle requests to /api/kernelspecs
@@ -15,13 +15,23 @@ export class KernelSpecs implements IKernelSpecs {
     if (this._specs.size === 0) {
       return null;
     }
-    // pick the first kernel if there is no default
-    const defaultKernelName =
-      PageConfig.getOption('defaultKernelName') || this._specs.keys().next().value;
+
     return {
-      default: defaultKernelName,
+      default: this.defaultKernelName,
       kernelspecs: Object.fromEntries(this._specs),
     };
+  }
+
+  /**
+   * Get the default kernel name.
+   */
+  get defaultKernelName(): string {
+    let defaultKernelName = PageConfig.getOption('defaultKernelName');
+
+    if (!defaultKernelName && this._specs.size) {
+      defaultKernelName = this._specs.keys().next().value;
+    }
+    return defaultKernelName || FALLBACK_KERNEL;
   }
 
   /**

--- a/packages/kernel/src/tokens.ts
+++ b/packages/kernel/src/tokens.ts
@@ -19,6 +19,11 @@ import { KernelSpecs } from './kernelspecs';
 export const IKernels = new Token<IKernels>('@jupyterlite/kernel:IKernels');
 
 /**
+ * The kernel name of last resort.
+ */
+export const FALLBACK_KERNEL = 'javascript';
+
+/**
  * An interface for the Kernels service.
  */
 export interface IKernels {
@@ -124,6 +129,11 @@ export interface IKernelSpecs {
    * Get the kernel specs.
    */
   readonly specs: KernelSpec.ISpecModels | null;
+
+  /**
+   * Get the default kernel name.
+   */
+  readonly defaultKernelName: string;
 
   /**
    * Get the kernel factories for the current kernels.


### PR DESCRIPTION
## References

- sub-pr of #[698](https://github.com/jupyterlite/jupyterlite/pull/698)

## Code changes

- [x] sorts kernel keys for default
- [x] adds lightest-weight fallback kernel
- [x] describes the above 

## User-facing changes

- n/a

## Backwards-incompatible changes

- n/a